### PR TITLE
feat: отправка заявки через create_order

### DIFF
--- a/client/frontend/js/schedule/scheduleDetails.js
+++ b/client/frontend/js/schedule/scheduleDetails.js
@@ -1,6 +1,14 @@
 import { updateScheduleStatus, deleteSchedule } from './scheduleApi.js';
 import { editSchedule } from './scheduleEditForm.js';
-import { createOrder } from '../requestForm.js';
+
+// Функция открытия формы заявки
+export function createOrder(scheduleId, city, warehouse) {
+    if (typeof window.openRequestFormModal === 'function') {
+        window.openRequestFormModal(scheduleId, city, warehouse);
+    }
+}
+// Делаем функцию глобальной для вызова из HTML
+window.createOrder = createOrder;
 
 export function openSingleShipmentModal(sh) {
     const modalContainer = document.getElementById('modalContainer');


### PR DESCRIPTION
## Summary
- ensure schedule modal opens request form
- send reception form data to `create_order.php` and show operation status

## Testing
- `node --check client/form.js`
- `node --check client/frontend/js/schedule/scheduleDetails.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c592de375c8333a718336673edd00a