### PR TITLE
fix: update schedule API base path

### DIFF
--- a/client/frontend/js/schedule/scheduleApi.js
+++ b/client/frontend/js/schedule/scheduleApi.js
@@ -1,4 +1,4 @@
-const API_BASE = '/backend/schedule';
+const API_BASE = '/client/backend/schedule';
 
 export async function fetchSchedules(params = {}) {
     const query = new URLSearchParams(params).toString();


### PR DESCRIPTION
## Summary
- use `/client/backend/schedule` as schedule API root

## Testing
- `curl -i http://127.0.0.1:8000/client/backend/schedule/listSchedules.php`
- `curl -i http://127.0.0.1:8000/client/backend/schedule/getSchedule.php?id=1`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59a7339488333b8ff835696d40a73