### PR TITLE
Redirect client logins to dashboard

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -93,7 +93,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         // Перенаправление на соответствующую главную страницу после успешного входа
         if ($role === 'client') {
-            header('Location: /client/index.php');
+            header('Location: /client/dashboard.php');
         } else {
             header('Location: index.php');
         }

--- a/client/auth.php
+++ b/client/auth.php
@@ -65,7 +65,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
 
-        header("Location: index.php");
+        header("Location: dashboard.php");
         exit();
     } else {
         header('Location: auth_form.php?error=Неправильный Email, номер телефона или пароль');


### PR DESCRIPTION
## Summary
- Redirect client role in authentication scripts to `/client/dashboard.php`
- Leave existing session/cookie logic to keep users logged in across redirects

## Testing
- `php -l auth.php`
- `php -l client/auth.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5a177bfa88333b7190c4c0b2d0e1d