### PR TITLE
Centralize schedule API base path

### DIFF
--- a/client/frontend/js/schedule/scheduleApi.js
+++ b/client/frontend/js/schedule/scheduleApi.js
@@ -1,16 +1,18 @@
+export const API_BASE = '/client/backend/schedule';
+
 export async function fetchSchedules(params = {}) {
     const query = new URLSearchParams(params).toString();
-    const res = await fetch(`/client/backend/schedule/listSchedules.php?${query}`);
+    const res = await fetch(`${API_BASE}/listSchedules.php?${query}`);
     return await res.json();
 }
 
 export async function getSchedule(id) {
-    const res = await fetch(`/client/backend/schedule/getSchedule.php?id=${id}`);
+    const res = await fetch(`${API_BASE}/getSchedule.php?id=${id}`);
     return await res.json();
 }
 
 export async function createSchedule(data) {
-    const res = await fetch('/client/backend/schedule/createSchedule.php', {
+    const res = await fetch(`${API_BASE}/createSchedule.php`, {
         method: 'POST',
         body: data
     });
@@ -20,7 +22,7 @@ export async function createSchedule(data) {
 export async function editSchedule(id, data) {
     const fd = new FormData(data);
     fd.append('id', id);
-    const res = await fetch('/client/backend/schedule/editSchedule.php', {
+    const res = await fetch(`${API_BASE}/editSchedule.php`, {
         method: 'POST',
         body: fd
     });
@@ -30,7 +32,7 @@ export async function editSchedule(id, data) {
 export async function deleteSchedule(id) {
     const fd = new FormData();
     fd.append('id', id);
-    const res = await fetch('/client/backend/schedule/deleteSchedule.php', {
+    const res = await fetch(`${API_BASE}/deleteSchedule.php`, {
         method: 'POST',
         body: fd
     });
@@ -40,7 +42,7 @@ export async function updateScheduleStatus(id, status) {
     const fd = new FormData();
     fd.append('id', id);
     fd.append('status', status);
-    const res = await fetch('/client/backend/schedule/updateScheduleStatus.php', {
+    const res = await fetch(`${API_BASE}/updateScheduleStatus.php`, {
         method: 'POST',
         body: fd
     });
@@ -48,7 +50,7 @@ export async function updateScheduleStatus(id, status) {
 }
 
 export async function exportSchedules() {
-    const res = await fetch('/client/backend/schedule/exportSchedules.php', {
+    const res = await fetch(`${API_BASE}/exportSchedules.php`, {
         method: 'POST'
     });
     return await res.blob();
@@ -57,7 +59,7 @@ export async function bulkUpdate(ids, action) {
     const fd = new FormData();
     ids.forEach(id => fd.append('ids[]', id));
     fd.append('action', action);
-    const res = await fetch('/client/backend/schedule/bulkUpdateSchedules.php', {
+    const res = await fetch(`${API_BASE}/bulkUpdateSchedules.php`, {
         method: 'POST',
         body: fd
     });

--- a/client/frontend/js/schedule/scheduleDetails.js
+++ b/client/frontend/js/schedule/scheduleDetails.js
@@ -1,4 +1,4 @@
-import { updateScheduleStatus, deleteSchedule } from './scheduleApi.js';
+import { updateScheduleStatus, deleteSchedule, API_BASE } from './scheduleApi.js';
 import { editSchedule } from './scheduleEditForm.js';
 import { createOrder } from '../requestForm.js';
 
@@ -64,7 +64,7 @@ export function canCreateOrderForSchedule(schedule) {
     return now <= deadlineDate;
 }
 export function openShipmentsForDate(date) {
-    fetch(`/client/backend/schedule/listSchedules.php?date=${encodeURIComponent(date)}`)
+    fetch(`${API_BASE}/listSchedules.php?date=${encodeURIComponent(date)}`)
         .then(r => r.json())
         .then(data => {
             const modalContainer = document.getElementById('modalContainer');

--- a/requestForm.js
+++ b/requestForm.js
@@ -1,3 +1,5 @@
+const API_BASE = '/client/backend/schedule';
+
 function openRequestFormModal(scheduleId, city = "", warehouses = "") {
     const modal = document.getElementById("requestModal");
     const content = document.getElementById("requestModalContent");
@@ -9,7 +11,7 @@ function openRequestFormModal(scheduleId, city = "", warehouses = "") {
 
     console.log("📦 Открываем модалку с расписанием ID:", scheduleId);
 
-    fetch(`/backend/schedule/getSchedule.php?id=${scheduleId}`)
+    fetch(`${API_BASE}/getSchedule.php?id=${scheduleId}`)
         .then(response => {
             if (!response.ok) throw new Error("Ошибка загрузки расписания");
             return response.json();


### PR DESCRIPTION
## Summary
- centralize PHP schedule API path via API_BASE constant
- update schedule details and request form to use API_BASE

## Testing
- `php client/backend/schedule/listSchedules.php` *(fails: No such file or directory)*
- `php -r '$_GET["id"] = 1; include "client/backend/schedule/getSchedule.php";'` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a3b0f660833392bf96e22c49c2de