### PR TITLE
fix: correct requestForm path in schedule modules

### DIFF
--- a/23-main/frontend/js/schedule/scheduleDetails.js
+++ b/23-main/frontend/js/schedule/scheduleDetails.js
@@ -1,6 +1,6 @@
 import { updateScheduleStatus, deleteSchedule } from './scheduleApi.js';
 import { editSchedule } from './scheduleEditForm.js';
-import { createOrder } from '../requestForm.js';
+import { createOrder } from '/client/requestForm.js';
 
 export function openSingleShipmentModal(sh) {
     const modalContainer = document.getElementById('modalContainer');

--- a/client/frontend/js/schedule/scheduleDetails.js
+++ b/client/frontend/js/schedule/scheduleDetails.js
@@ -1,6 +1,6 @@
 import { updateScheduleStatus, deleteSchedule, API_BASE } from './scheduleApi.js';
 import { editSchedule } from './scheduleEditForm.js';
-import { createOrder } from '../requestForm.js';
+import { createOrder } from '/client/requestForm.js';
 
 export function openSingleShipmentModal(sh) {
     const modalContainer = document.getElementById('modalContainer');


### PR DESCRIPTION
## Summary
- fix path to requestForm.js in schedule details modules to reference /client/requestForm.js

## Testing
- `node --check client/frontend/js/schedule/scheduleDetails.js`
- `node --check 23-main/frontend/js/schedule/scheduleDetails.js`
- `python3 -m http.server 8000 & curl -I http://localhost:8000/client/requestForm.js`

------
https://chatgpt.com/codex/tasks/task_e_68c5a639127c8333bfb7271cae71b5c4