### PR TITLE
feat: defer schedule module

### DIFF
--- a/client/dashboard.php
+++ b/client/dashboard.php
@@ -121,7 +121,7 @@ $role = $_SESSION['role'];
 <!-- Предпросмотр фото и галерея изображений -->
 <script src="/client/photoPreview.js?v=<?php echo $version; ?>"></script>
 <!-- Модуль "Расписание": импортирует scheduleMain.js и задаёт loadSchedule() -->
-<script type="module" src="/client/schedule.js?v=<?=$version?>"></script>
+<script type="module" src="/client/schedule.js?v=<?=$version?>" defer></script>
 <!-- Библиотека QRCode.js для генерации QR-кодов -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 <!-- Библиотека pdfmake для формирования PDF-файлов -->

--- a/client/index.php
+++ b/client/index.php
@@ -150,7 +150,7 @@ $role = $_SESSION['role'];
 <!-- Предпросмотр фото и галерея изображений -->
 <script src="/client/photoPreview.js?v=<?php echo $version; ?>"></script>
 <!-- Модуль "Расписание": импортирует scheduleMain.js и задаёт loadSchedule() -->
-<script type="module" src="/client/schedule.js?v=<?=$version?>"></script>
+<script type="module" src="/client/schedule.js?v=<?=$version?>" defer></script>
 <!-- Библиотека QRCode.js для генерации QR-кодов -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 <!-- Библиотека pdfmake для формирования PDF-файлов -->


### PR DESCRIPTION
## Summary
- ensure schedule module loads after parsing by deferring client pages

## Testing
- `php -l client/index.php client/dashboard.php`
- `curl -I http://localhost:8000/client/schedule.js`
- `curl -I http://localhost:8000/client/frontend/js/schedule/scheduleMain.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5a6f8b74c8333998df7c8ecf4cc16