### PR TITLE
Убраны проверки ролей на навигации

### DIFF
--- a/index.php
+++ b/index.php
@@ -68,13 +68,11 @@ const currentClientId = '<?php echo $_SESSION['user_id'] ?? 0; ?>';
 
 <div class="main-panel">
     <div class="navigation">
-        <?php if ($role === 'admin' || $role === 'manager'): ?>
             <button class="icon-button" onclick="loadForm()"><i class="fas fa-box"></i> Приёмка</button>
             <button class="icon-button" onclick="loadProcessing()"><i class="fas fa-cogs"></i> Обработка</button>
             <button class="icon-button" onclick="loadFBS()"><i class="fas fa-warehouse"></i> FBS</button>
             <button class="icon-button" onclick="loadAllOrders()"><i class="fas fa-list"></i> Все заказы</button>
             <button class="icon-button" onclick="loadTable()"><i class="fas fa-table"></i> Таблица</button>
-        <?php endif; ?>
 
             <button id="tariffsBtn" class="icon-button">
                 <i class="fas fa-money-bill"></i> Тарифы
@@ -82,16 +80,10 @@ const currentClientId = '<?php echo $_SESSION['user_id'] ?? 0; ?>';
 
         <button class="icon-button" onclick="loadSchedule()"><i class="fas fa-calendar"></i> Расписание</button>
 
-        <?php if ($role === 'admin' || $role === 'manager'): ?>
             <button class="icon-button" onclick="loadStatistics()"><i class="fas fa-chart-pie"></i> Статистика</button>
-        <?php endif; ?>
 
-        <?php if ($role === 'admin' || $role === 'manager'): ?>
             <button class="icon-button" onclick="loadClients()"><i class="fas fa-users"></i> Клиенты</button>
-        <?php endif; ?>
-        <?php if ($role === 'admin'): ?>
             <button class="icon-button" onclick="loadSystemLogs()"><i class="fas fa-tools"></i> Система</button>
-        <?php endif; ?>
 
         <button class="icon-button" id="notificationsBtn">
             <i class="fas fa-bell"></i>
@@ -105,10 +97,8 @@ const currentClientId = '<?php echo $_SESSION['user_id'] ?? 0; ?>';
             <div class="profile-dropdown" id="profileDropdown">
                 <ul>
                     <li onclick="loadOrders()">Мои заказы</li>
-                    <?php if ($role === 'admin'): ?>
-                        <li onclick="loadChangeHistory()">История изменений</li>
-                        <li onclick="loadScheduleSettings()">Настройки расписания</li>
-                    <?php endif; ?>
+                    <li onclick="loadChangeHistory()">История изменений</li>
+                    <li onclick="loadScheduleSettings()">Настройки расписания</li>
                     <li onclick="loadEditData()">Редактирование данных</li>
                     <li onclick="loadSettings()">Настройки</li>
                     <li><a href="logout.php">Выйти</a></li>
@@ -122,12 +112,10 @@ const currentClientId = '<?php echo $_SESSION['user_id'] ?? 0; ?>';
 
 <!-- Мобильная нижняя навигация -->
 <nav class="mobile-tab-bar">
-    <?php if ($role === 'admin' || $role === 'manager'): ?>
-        <!-- Приёмка (для админа и менеджера) -->
+        <!-- Приёмка -->
         <button onclick="loadForm()" title="Приёмка">
             <i class="fas fa-inbox"></i>
         </button>
-    <?php endif; ?>
 
     <!-- Расписание -->
     <button onclick="loadSchedule()" title="Расписание">
@@ -144,7 +132,6 @@ const currentClientId = '<?php echo $_SESSION['user_id'] ?? 0; ?>';
         <i class="fas fa-money-bill"></i>
     </button>
 
-    <?php if ($role === 'admin' || $role === 'manager'): ?>
         <!-- FBS -->
         <button onclick="loadFBS()" title="FBS">
             <i class="fas fa-warehouse"></i>
@@ -157,7 +144,6 @@ const currentClientId = '<?php echo $_SESSION['user_id'] ?? 0; ?>';
         <button onclick="loadTable()" title="Таблица">
             <i class="fas fa-table"></i>
         </button>
-    <?php endif; ?>
 
     <!-- Профиль -->
     <button onclick="toggleMobileProfileMenu()" title="Профиль">
@@ -169,20 +155,11 @@ const currentClientId = '<?php echo $_SESSION['user_id'] ?? 0; ?>';
 
 <!-- Мобильное выдвижное меню профиля -->
 <div class="mobile-profile-menu" id="mobileProfileMenu">
-    <?php if ($role === 'admin'): ?>
         <button onclick="loadEditData()">Редактировать данные</button>
         <button onclick="loadOrders()">Мои заказы</button>
         <button onclick="loadChangeHistory()">История изменений</button>
         <button onclick="loadScheduleSettings()">Настройки расписания</button>
         <a href="logout.php">Выйти</a>
-    <?php elseif ($role === 'manager'): ?>
-        <button onclick="loadEditData()">Редактировать данные</button>
-        <button onclick="loadOrders()">Мои заказы</button>
-        <a href="logout.php">Выйти</a>
-    <?php else: ?>
-        <button onclick="loadOrders()">Мои заказы</button>
-        <a href="logout.php">Выйти</a>
-    <?php endif; ?>
 </div>
 
 <div class="modal" id="requestModal">


### PR DESCRIPTION
## Summary
- убрана условная логика показа меню в `index.php`
- мобильные навигация и меню профиля теперь одинаковы для админов и менеджеров
- клиенты перенаправляются на `client/dashboard.php`

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5b62f2e0c8333aa42dcfcccb74f01