### PR TITLE
Исправлены относительные пути в модулях расписания

### DIFF
--- a/client/frontend/js/schedule/scheduleApi.js
+++ b/client/frontend/js/schedule/scheduleApi.js
@@ -1,16 +1,16 @@
 export async function fetchSchedules(params = {}) {
     const query = new URLSearchParams(params).toString();
-    const res = await fetch(`/backend/schedule/listSchedules.php?${query}`);
+    const res = await fetch(`backend/schedule/listSchedules.php?${query}`);
     return await res.json();
 }
 
 export async function getSchedule(id) {
-    const res = await fetch(`/backend/schedule/getSchedule.php?id=${id}`);
+    const res = await fetch(`backend/schedule/getSchedule.php?id=${id}`);
     return await res.json();
 }
 
 export async function createSchedule(data) {
-    const res = await fetch('/backend/schedule/createSchedule.php', {
+    const res = await fetch('backend/schedule/createSchedule.php', {
         method: 'POST',
         body: data
     });
@@ -20,7 +20,7 @@ export async function createSchedule(data) {
 export async function editSchedule(id, data) {
     const fd = new FormData(data);
     fd.append('id', id);
-    const res = await fetch('/backend/schedule/editSchedule.php', {
+    const res = await fetch('backend/schedule/editSchedule.php', {
         method: 'POST',
         body: fd
     });
@@ -30,7 +30,7 @@ export async function editSchedule(id, data) {
 export async function deleteSchedule(id) {
     const fd = new FormData();
     fd.append('id', id);
-    const res = await fetch('/backend/schedule/deleteSchedule.php', {
+    const res = await fetch('backend/schedule/deleteSchedule.php', {
         method: 'POST',
         body: fd
     });
@@ -40,7 +40,7 @@ export async function updateScheduleStatus(id, status) {
     const fd = new FormData();
     fd.append('id', id);
     fd.append('status', status);
-    const res = await fetch('/backend/schedule/updateScheduleStatus.php', {
+    const res = await fetch('backend/schedule/updateScheduleStatus.php', {
         method: 'POST',
         body: fd
     });
@@ -48,7 +48,7 @@ export async function updateScheduleStatus(id, status) {
 }
 
 export async function exportSchedules() {
-    const res = await fetch('/backend/schedule/exportSchedules.php', {
+    const res = await fetch('backend/schedule/exportSchedules.php', {
         method: 'POST'
     });
     return await res.blob();
@@ -57,7 +57,7 @@ export async function bulkUpdate(ids, action) {
     const fd = new FormData();
     ids.forEach(id => fd.append('ids[]', id));
     fd.append('action', action);
-    const res = await fetch('/backend/schedule/bulkUpdateSchedules.php', {
+    const res = await fetch('backend/schedule/bulkUpdateSchedules.php', {
         method: 'POST',
         body: fd
     });

--- a/client/frontend/js/schedule/scheduleDetails.js
+++ b/client/frontend/js/schedule/scheduleDetails.js
@@ -64,7 +64,7 @@ export function canCreateOrderForSchedule(schedule) {
     return now <= deadlineDate;
 }
 export function openShipmentsForDate(date) {
-    fetch(`/backend/schedule/listSchedules.php?date=${encodeURIComponent(date)}`)
+    fetch(`backend/schedule/listSchedules.php?date=${encodeURIComponent(date)}`)
         .then(r => r.json())
         .then(data => {
             const modalContainer = document.getElementById('modalContainer');


### PR DESCRIPTION
## Summary
- fix schedule API module paths to be relative to `client`
- update schedule details module fetch to use relative backend path

## Testing
- `node --check client/frontend/js/schedule/scheduleApi.js`
- `node --check client/frontend/js/schedule/scheduleDetails.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5d7c798548333a0ae4a47a7ca457e