### PR TITLE
Restrict admin scripts with role checks

### DIFF
--- a/export_schedule_template.php
+++ b/export_schedule_template.php
@@ -1,4 +1,13 @@
 <?php
+require_once 'session_init.php';
+session_start();
+
+// Доступ только для администраторов и менеджеров
+if (!isset($_SESSION['role']) || !in_array($_SESSION['role'], ['admin', 'manager'])) {
+    header('Location: auth_form.php');
+    exit();
+}
+
 header('Content-Type: text/csv; charset=utf-8');
 header('Content-Disposition: attachment; filename="шаблон_расписания.csv"');
 

--- a/export_to_excel.php
+++ b/export_to_excel.php
@@ -1,4 +1,13 @@
 <?php
+require_once 'session_init.php';
+session_start();
+
+// Проверяем роль пользователя: доступ только для администраторов и менеджеров
+if (!isset($_SESSION['role']) || !in_array($_SESSION['role'], ['admin', 'manager'])) {
+    header('Location: auth_form.php');
+    exit();
+}
+
 require_once 'db_connection.php';
 require 'vendor/autoload.php';
 

--- a/manual_reception.php
+++ b/manual_reception.php
@@ -1,5 +1,14 @@
 <?php
 header('Content-Type: application/json');
+require_once 'session_init.php';
+session_start();
+
+// Проверяем роль: только админ или менеджер могут создавать заявки вручную
+if (!isset($_SESSION['role']) || !in_array($_SESSION['role'], ['admin', 'manager'])) {
+    http_response_code(403);
+    echo json_encode(['status' => 'error', 'message' => 'Доступ запрещён']);
+    exit();
+}
 
 // Подключаемся к базе (поменяйте на своё подключение)
 require_once 'config.php';

--- a/notify_create.php
+++ b/notify_create.php
@@ -1,9 +1,19 @@
 <?php
+require_once 'session_init.php';
+session_start();
+
+// Разрешаем отправку уведомлений только администраторам и менеджерам
+$role = $_SESSION['role'] ?? '';
+if (!in_array($role, ['admin', 'manager'])) {
+    http_response_code(403);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['success' => false, 'message' => 'Доступ запрещён']);
+    exit();
+}
+
 require_once 'db_connection.php';
 require_once 'notify_user.php';
 header('Content-Type: application/json; charset=utf-8');
-require_once 'session_init.php';
-session_start();
 
 // Получение user_id через POST (или можешь брать из сессии)
 $userId = intval($_POST['user_id'] ?? 0);


### PR DESCRIPTION
## Summary
- add role check for manual reception and notification creation
- secure export scripts to allow only admin/manager

## Testing
- `php -l export_to_excel.php`
- `php -l export_schedule_template.php`
- `php -l manual_reception.php`
- `php -l notify_create.php`
- `php -r 'session_start(); $_SESSION["role"]="client"; $_SERVER["REQUEST_METHOD"]="POST"; include "manual_reception.php";'`
- `php -r 'session_start(); $_SESSION["role"]="client"; $_POST["user_id"]=1; $_POST["message"]="hi"; include "notify_create.php";'`


------
https://chatgpt.com/codex/tasks/task_e_68c5d888c52c8333b576120fcae96d32