### PR TITLE
Redirect clients to client area after login

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -90,8 +90,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $conn->query("UPDATE usersff SET remember_token = NULL, token_expiry = NULL WHERE id = " . (int)$user['id']);
         }
 
-        // Перенаправление на главную страницу после успешного входа
-        header('Location: index.php');
+        // Перенаправление после успешного входа
+        if ($_SESSION['role'] === 'client') {
+            header('Location: client/index.php');
+        } else {
+            header('Location: index.php');
+        }
         exit();
     } else {
         // Неверные учетные данные


### PR DESCRIPTION
## Summary
- Redirect authenticated clients to `/client/index.php`
- Preserve existing redirect to main index for other roles

## Testing
- `php -l auth.php`
- `curl -i -X POST -d 'phone=123&password=123' http://127.0.0.1:8000/auth.php` *(fails: No such file or directory for MySQL)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fa25fc5c8333bf85d4cdc970dd45