### PR TITLE
Добавлен условный редирект при авторизации

### DIFF
--- a/auth_form.php
+++ b/auth_form.php
@@ -49,7 +49,11 @@ if (!isset($_SESSION['role']) && isset($_COOKIE['remember_token'], $_COOKIE['rem
 
 // Авторизованным пользователям – на главную
 if (isset($_SESSION['role'])) {
-    header('Location: index.php');
+    if ($_SESSION['role'] === 'client') {
+        header('Location: client/index.php');
+    } else {
+        header('Location: index.php');
+    }
     exit();
 }
 ?>


### PR DESCRIPTION
## Summary
- Уточнён редирект авторизованных пользователей: клиенты отправляются в `client/index.php`, остальные — на главную

## Testing
- `php -l auth_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68c60480e560833380fc04a0f5cd94ce