### PR TITLE
feat: add API services and env configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/node_modules/
+client/dist/
+client/.env.local

--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/client/src/api/http.ts
+++ b/client/src/api/http.ts
@@ -1,0 +1,11 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+
+export async function apiFetch<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}/${endpoint}`, options);
+  if (!response.ok) {
+    throw new Error(`API request failed with status ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export { API_BASE_URL };

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,0 +1,3 @@
+export * from './http';
+export * from './useClientInfo';
+export * from './useOrders';

--- a/client/src/api/useClientInfo.ts
+++ b/client/src/api/useClientInfo.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { apiFetch } from './http';
+
+export interface ClientInfo {
+  id: number;
+  email: string;
+  phone: string;
+  first_name: string;
+  last_name: string;
+  registration_date: string;
+  total_orders: number;
+  total_sum: number;
+  last_activity: string;
+  statuses: Record<string, number>;
+}
+
+interface ClientInfoResponse {
+  success: boolean;
+  client: ClientInfo;
+}
+
+export function useClientInfo(userId: number) {
+  const [data, setData] = useState<ClientInfo | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    setLoading(true);
+    apiFetch<ClientInfoResponse>(`get_client_info.php?user_id=${userId}`)
+      .then((res) => {
+        if (res.success) {
+          setData(res.client);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  return { data, loading };
+}

--- a/client/src/api/useOrders.ts
+++ b/client/src/api/useOrders.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { apiFetch } from './http';
+
+export interface Order {
+  id: number;
+  route: string;
+  status: string;
+  marketplace: string;
+  order_date: string;
+}
+
+interface OrdersResponse {
+  success: boolean;
+  orders: Order[];
+}
+
+export function useOrders(userId: number) {
+  const [data, setData] = useState<Order[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    setLoading(true);
+    apiFetch<OrdersResponse>(`get_orders.php?user_id=${userId}`)
+      .then((res) => {
+        if (res.success) {
+          setData(res.orders);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  return { data, loading };
+}

--- a/client/src/pages/ClientDashboard.tsx
+++ b/client/src/pages/ClientDashboard.tsx
@@ -1,19 +1,42 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { Calendar, CreditCard, Package, TrendingUp, MapPin, Truck } from 'lucide-react';
+import { Calendar, CreditCard, Package, TrendingUp, Truck } from 'lucide-react';
+import { useClientInfo, useOrders } from '../api';
 
 const ClientDashboard: React.FC = () => {
-  const stats = [
-    { name: 'Активные заказы', value: '12', icon: Package, color: 'bg-blue-500' },
-    { name: 'Ближайшие отправления', value: '3', icon: Truck, color: 'bg-green-500' },
-    { name: 'В пути', value: '7', icon: MapPin, color: 'bg-orange-500' },
-    { name: 'Завершено за месяц', value: '45', icon: TrendingUp, color: 'bg-purple-500' },
-  ];
+  const userId = 1; // временно захардкожен для демонстрации
+  const { data: clientInfo } = useClientInfo(userId);
+  const { data: orders } = useOrders(userId);
 
-  const upcomingShipments = [
-    { id: 1, route: 'Хасавюрт → Коледино', date: 'Завтра, 15:00', marketplace: 'Wildberries' },
-    { id: 2, route: 'Хасавюрт → Электросталь', date: '25.01, 10:00', marketplace: 'Ozon' },
-  ];
+  const stats = useMemo(() => {
+    if (!clientInfo) {
+      return [];
+    }
+    const statuses = clientInfo.statuses || {};
+    return [
+      {
+        name: 'Активные заказы',
+        value: String(statuses['Активные'] ?? 0),
+        icon: Package,
+        color: 'bg-blue-500',
+      },
+      {
+        name: 'Завершено за месяц',
+        value: String(statuses['Завершено'] ?? 0),
+        icon: TrendingUp,
+        color: 'bg-purple-500',
+      },
+    ];
+  }, [clientInfo]);
+
+  const upcomingShipments = useMemo(() => {
+    return orders.slice(0, 2).map((o) => ({
+      id: o.id,
+      route: o.route,
+      date: o.order_date,
+      marketplace: o.marketplace,
+    }));
+  }, [orders]);
 
   return (
     <div className="space-y-8">


### PR DESCRIPTION
## Summary
- add Vite `.env` with base API URL
- create reusable fetch helpers and hooks for PHP endpoints
- load client and orders data in dashboard via new hooks

## Testing
- `npm run lint`
- `npm run build`
- `curl http://localhost:8000/get_orders.php` *(fails: No such file or directory)*
- `curl -v http://localhost:8000/get_client_info.php?user_id=1` *(500 Internal Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_68c60f3ae1048333a64471ec561694b3