### PR TITLE
fix: redirect logo link to client root

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -34,7 +34,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             {/* Logo */}
-            <Link to="/" className="flex items-center space-x-2">
+            <Link to="/client" className="flex items-center space-x-2">
               <div className="w-8 h-8 bg-gradient-to-r from-green-500 to-green-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">FF</span>
               </div>


### PR DESCRIPTION
## Summary
- ensure header logo stays within client app by linking to `/client`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c614da002c8333a5ca36496396619a