### PR TITLE
Redirect clients to dedicated portal

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -68,6 +68,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['user_id'] = $user['id'];
         $_SESSION['role']    = $user['role'];
 
+        if ($user['role'] === 'client') {
+            header('Location: /client/index.html');
+            exit();
+        }
+
         if ($remember) {
             // Генерация токена для "Запомнить меня" на 60 дней
             $token     = bin2hex(random_bytes(16));

--- a/index.php
+++ b/index.php
@@ -5,6 +5,10 @@ if (!isset($_SESSION['role'])) {
     header('Location: auth_form.php');
     exit();
 }
+if ($_SESSION['role'] === 'client') {
+    header('Location: /client/index.html');
+    exit();
+}
 $role = $_SESSION['role'];
 
 // Если у пользователя роль "deliverer", отправляем его на страницу курьера


### PR DESCRIPTION
## Summary
- Redirect clients to their dedicated portal during authentication
- Guard index page to forward client sessions to client portal

## Testing
- `php -l auth.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6348a12d08333abd404cb7c6ada3d