### PR TITLE
feat: calculate request cost from tariffs

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -523,7 +523,7 @@ class ScheduleManager {
         }
 
         if (typeof window.openRequestFormModal === 'function') {
-            window.openRequestFormModal(schedule.id, schedule.city, schedule.warehouses);
+            window.openRequestFormModal(schedule);
         }
     }
 }

--- a/schedule.js
+++ b/schedule.js
@@ -937,7 +937,7 @@ function openSingleShipmentModal(sh) {
 
         <div class="modal-actions">
             ${canCreateOrderForSchedule(sh) ? `
-                <button class="create-order-btn big-action" onclick="createOrder(${sh.id}, '${sh.city}', '${sh.warehouses}')">
+                <button class="create-order-btn big-action" onclick="createOrder(${sh.id}, '${sh.city}', '${sh.warehouses}', '${sh.marketplace}')">
                     <i class="fas fa-plus-circle"></i> Создать заявку
                 </button>
             ` : `<span class="closed-message">Приём заявок закрыт</span>`}
@@ -1124,7 +1124,7 @@ function fetchAndDisplayUpcoming(showArchived = false, statusCategory = 'active'
                         div.className = "upcoming-item styled-upcoming-item";
                         if (canOrder) {
                             div.classList.add("card-clickable");
-                            div.addEventListener("click", () => openRequestFormModal(sh.id));
+                            div.addEventListener("click", () => openRequestFormModal(sh));
                         }
 
                         div.innerHTML = `
@@ -2191,11 +2191,11 @@ function fetchScheduleData() {
  * Главное изменение: мы не переходим на "processing.html",
  * а просто закрываем модалку (или можем открыть нужный раздел).
  */
-function createOrder(scheduleId, city, warehouse) {
+function createOrder(scheduleId, city, warehouse, marketplace) {
     // Вместо перехода на processing.html,
     // вызываем нашу функцию из requestForm.js
     closeScheduleModal(); // если было открыто окно расписания
-    openRequestFormModal(scheduleId, city, warehouse);
+    openRequestFormModal({ id: scheduleId, city, warehouses: warehouse, marketplace });
 }
 
 function openShipmentsForDate(date) {

--- a/schedules/scheduleModal.js
+++ b/schedules/scheduleModal.js
@@ -61,7 +61,7 @@ function openSingleShipmentModal(sh) {
 
         ${
             canOrder
-                ? `<button onclick="createOrder(${sh.id}, '${sh.city}', '${sh.warehouses}')">Создать заявку</button>`
+                ? `<button onclick="createOrder(${sh.id}, '${sh.city}', '${sh.warehouses}', '${sh.marketplace}')">Создать заявку</button>`
                 : `<p>Приём заявок закрыт</p>`
         }
 
@@ -363,10 +363,10 @@ function archiveSchedule(id) {
 }
 
 // Создаёт заявку на отправление. Закрывает текущую модалку и открывает форму заявки.
-function createOrder(scheduleId, city, warehouse) {
+function createOrder(scheduleId, city, warehouse, marketplace) {
     closeScheduleModal(); // закрываем окно расписания
     if (typeof openRequestFormModal === 'function') {
-        openRequestFormModal(scheduleId, city, warehouse);
+        openRequestFormModal({ id: scheduleId, city, warehouses: warehouse, marketplace });
     }
 }
 


### PR DESCRIPTION
## Summary
- compute order cost in `requestForm` using tariffs and marketplace multipliers
- pass schedule object when opening request form and prefill formatted cost

## Testing
- `node --check requestForm.js`
- `node --check client/js/schedule.js`
- `node --check schedule.js`
- `node --check schedules/scheduleModal.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6af2cdd308333aa7ffbbde4f23a22