### PR TITLE
Fix request form modal template path

### DIFF
--- a/requestForm.js
+++ b/requestForm.js
@@ -34,7 +34,7 @@ async function openRequestFormModal(scheduleOrId, city = "", warehouse = "", mar
             : { id: scheduleOrId, city, warehouses: warehouse, marketplace };
 
     try {
-        const tmplResp = await fetch('client/templates/orderModal.html');
+        const tmplResp = await fetch('/client/templates/orderModal.html');
         const tmplHtml = await tmplResp.text();
         const wrap = document.createElement('div');
         wrap.innerHTML = tmplHtml.trim();


### PR DESCRIPTION
## Summary
- Use absolute path when fetching order modal template to avoid 404 in client pages

## Testing
- `curl -I http://localhost:8000/client/templates/orderModal.html`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b23add548333b832a2060b5fa050