### PR TITLE
Добавить статистику по городам для бухгалтера

### DIFF
--- a/accountant/js/accountant.js
+++ b/accountant/js/accountant.js
@@ -628,34 +628,59 @@ class AccountantApp {
     }
 
     async loadCitiesChart() {
-        // Симуляция данных
-        const data = {
-            labels: ['Махачкала', 'Хасавюрт', 'Каспийск', 'Кизляр'],
-            datasets: [{
-                data: [35, 25, 20, 20],
-                backgroundColor: ['#3b82f6', '#10b981', '#f59e0b', '#ef4444']
-            }]
-        };
+        const canvasId = 'citiesChart';
+        const canvas = document.getElementById(canvasId);
+        const container = canvas.parentElement;
 
-        const ctx = document.getElementById('citiesChart').getContext('2d');
-        
-        if (this.charts.cities) {
-            this.charts.cities.destroy();
-        }
+        try {
+            const response = await fetch('../api/accountant/get_city_stats.php');
+            const result = await response.json();
 
-        this.charts.cities = new Chart(ctx, {
-            type: 'doughnut',
-            data: data,
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    legend: {
-                        position: 'bottom'
+            if (!result.success) {
+                throw new Error(result.message || 'Ошибка сервера');
+            }
+
+            const labels = result.labels || [];
+            const dataValues = result.data || [];
+
+            if (!labels.length || !dataValues.length) {
+                container.innerHTML = '<div class="empty-state"><p>Нет данных по городам</p></div>';
+                return;
+            }
+
+            container.innerHTML = `<canvas id="${canvasId}" width="300" height="300"></canvas>`;
+            const ctx = document.getElementById(canvasId).getContext('2d');
+
+            const data = {
+                labels: labels,
+                datasets: [{
+                    data: dataValues,
+                    backgroundColor: ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#14b8a6', '#f97316']
+                }]
+            };
+
+            if (this.charts.cities) {
+                this.charts.cities.destroy();
+            }
+
+            this.charts.cities = new Chart(ctx, {
+                type: 'doughnut',
+                data: data,
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: {
+                            position: 'bottom'
+                        }
                     }
                 }
-            }
-        });
+            });
+        } catch (error) {
+            console.error('Ошибка загрузки статистики по городам:', error);
+            this.showToast('Ошибка загрузки статистики по городам', 'error');
+            container.innerHTML = '<div class="empty-state"><p>Не удалось загрузить данные</p></div>';
+        }
     }
 
     async loadPaymentTypesChart() {

--- a/api/accountant/get_city_stats.php
+++ b/api/accountant/get_city_stats.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/../../error_handler.php';
+
+try {
+    session_start();
+    header('Content-Type: application/json; charset=UTF-8');
+    if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'accountant') {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Forbidden']);
+        exit;
+    }
+
+    require_once __DIR__ . '/../../db_connection.php';
+
+    $metric = $_GET['metric'] ?? 'orders'; // 'orders' or 'payments'
+
+    $sql = "SELECT city, COUNT(*) AS orders_count, COALESCE(SUM(payment),0) AS total_payment
+            FROM shipments
+            GROUP BY city";
+
+    $stmt = $conn->prepare($sql);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $labels = [];
+    $data   = [];
+    while ($row = $result->fetch_assoc()) {
+        $labels[] = $row['city'] ?: 'Не указан';
+        if ($metric === 'payments') {
+            $data[] = (float)$row['total_payment'];
+        } else {
+            $data[] = (int)$row['orders_count'];
+        }
+    }
+
+    $stmt->close();
+    $conn->close();
+
+    echo json_encode(['success' => true, 'labels' => $labels, 'data' => $data]);
+    exit;
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Internal Server Error']);
+    exit;
+}
+?>


### PR DESCRIPTION
## Summary
- Реализован API `get_city_stats.php` с группировкой отгрузок по городам
- Обновлена функция `loadCitiesChart` для загрузки данных из API и обновления диаграммы
- Добавлена обработка ошибок и отображение сообщений при отсутствии данных

## Testing
- `php -l api/accountant/get_city_stats.php`


------
https://chatgpt.com/codex/tasks/task_e_68c818acf7bc8333b7062cfc8735b394