### PR TITLE
Добавлен отчет по типам оплаты

### DIFF
--- a/accountant/js/accountant.js
+++ b/accountant/js/accountant.js
@@ -683,36 +683,64 @@ class AccountantApp {
         }
     }
 
+    
     async loadPaymentTypesChart() {
-        // Симуляция данных
-        const data = {
-            labels: ['Наличные', 'Т-Банк', 'Долг'],
-            datasets: [{
-                data: [45, 40, 15],
-                backgroundColor: ['#10b981', '#3b82f6', '#ef4444']
-            }]
-        };
+        const canvasId = 'paymentTypesChart';
+        const canvas = document.getElementById(canvasId);
+        const container = canvas.parentElement;
 
-        const ctx = document.getElementById('paymentTypesChart').getContext('2d');
-        
-        if (this.charts.paymentTypes) {
-            this.charts.paymentTypes.destroy();
-        }
+        try {
+            const response = await fetch('../api/accountant/get_payment_types.php');
+            const result = await response.json();
 
-        this.charts.paymentTypes = new Chart(ctx, {
-            type: 'pie',
-            data: data,
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    legend: {
-                        position: 'bottom'
+            if (!result.success) {
+                throw new Error(result.message || 'Ошибка сервера');
+            }
+
+            const labels = result.labels || [];
+            const dataValues = result.data || [];
+
+            if (!labels.length || !dataValues.length) {
+                container.innerHTML = '<div class="empty-state"><p>Нет данных</p></div>';
+                return;
+            }
+
+            container.innerHTML = `<canvas id="${canvasId}" width="300" height="300"></canvas>`;
+            const ctx = document.getElementById(canvasId).getContext('2d');
+
+            const data = {
+                labels: labels,
+                datasets: [{
+                    data: dataValues,
+                    backgroundColor: ['#10b981', '#3b82f6', '#ef4444', '#f59e0b', '#8b5cf6', '#ec4899', '#14b8a6', '#f97316']
+                }]
+            };
+
+            if (this.charts.paymentTypes) {
+                this.charts.paymentTypes.destroy();
+            }
+
+            this.charts.paymentTypes = new Chart(ctx, {
+                type: 'pie',
+                data: data,
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: {
+                            position: 'bottom'
+                        }
                     }
                 }
-            }
-        });
+            });
+        } catch (error) {
+            console.error('Ошибка загрузки статистики по типам оплаты:', error);
+            this.showToast('Ошибка загрузки статистики по типам оплаты', 'error');
+            container.innerHTML = '<div class="empty-state"><p>Не удалось загрузить данные</p></div>';
+        }
     }
+
+
 
     async loadTrendsChart(period) {
         // Симуляция данных трендов

--- a/api/accountant/get_payment_types.php
+++ b/api/accountant/get_payment_types.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/../../error_handler.php';
+
+try {
+    session_start();
+    header('Content-Type: application/json; charset=UTF-8');
+    if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'accountant') {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Forbidden']);
+        exit;
+    }
+
+    require_once __DIR__ . '/../../db_connection.php';
+
+    $sql = "SELECT COALESCE(d.payment_type, s.payment_type) AS payment_type, COUNT(*) AS cnt
+            FROM shipments s
+            LEFT JOIN order_reception_details d ON s.order_id = d.order_id
+            GROUP BY COALESCE(d.payment_type, s.payment_type)";
+
+    $stmt = $conn->prepare($sql);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $labels = [];
+    $data = [];
+    while ($row = $result->fetch_assoc()) {
+        $labels[] = $row['payment_type'] ?: 'Не указан';
+        $data[] = (int)$row['cnt'];
+    }
+
+    $stmt->close();
+    $conn->close();
+
+    echo json_encode(['success' => true, 'labels' => $labels, 'data' => $data]);
+    exit;
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Internal Server Error']);
+    exit;
+}
+?>


### PR DESCRIPTION
## Изменения
- Добавлен API-эндпоинт для статистики типов оплаты
- Обновлена диаграмма типов оплат в интерфейсе бухгалтера

## Проверка
- `php -l api/accountant/get_payment_types.php`
- `node --check accountant/js/accountant.js`


------
https://chatgpt.com/codex/tasks/task_e_68c819724bd8833391ba9110d1833c57