### PR TITLE
Скрыть модальные окна по умолчанию

### DIFF
--- a/styles/import.css
+++ b/styles/import.css
@@ -1,4 +1,4 @@
-/* Modal overlay (center content via flexbox) */
+/* Modal overlay (hidden by default, centered when shown) */
 .modal {
     display: none;
     position: fixed;
@@ -6,10 +6,12 @@
     top: 0; left: 0;
     width: 100%; height: 100%;
     background: rgba(0,0,0,0.5);
-    /* Center the modal content */
-    display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.modal.show {
+    display: flex;
 }
 
 /* Modal content container */

--- a/styles/table.css
+++ b/styles/table.css
@@ -105,6 +105,12 @@
 }
 
 /* ==== Новая таблица FBS и все современные таблицы (.table-container) ==== */
+
+/* Базовое состояние модальных окон: скрыты при загрузке */
+.modal {
+    display: none;
+}
+
 .table-container {
     width: 100%;
     background-color: #fff;

--- a/table/js/table.js
+++ b/table/js/table.js
@@ -316,16 +316,16 @@ class TableApp {
                 } else {
                     img.src = photoUrl;
                 }
-                modal.classList.add('active');
+                modal.classList.add('show');
             })
             .catch(() => {
                 img.src = photoUrl;
-                modal.classList.add('active');
+                modal.classList.add('show');
             });
     }
 
     closePhotoModal() {
-        document.getElementById('photoModal').classList.remove('active');
+        document.getElementById('photoModal').classList.remove('show');
     }
 
     showLoading(show) {

--- a/table/styles/table.css
+++ b/table/styles/table.css
@@ -602,7 +602,7 @@ body {
     justify-content: center;
 }
 
-.modal.active {
+.modal.show {
     display: flex;
 }
 


### PR DESCRIPTION
## Summary
- скрыты админские модалки по умолчанию за счёт базового правила в styles/table.css
- обновлена верстка модальных окон импорта для показа через класс .show
- приведены модалки в разделе таблицы к использованию класса .show вместо .active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c852d2b28c83339758fdeded7309bf