### PR TITLE
Adjust admin default load to schedule view

### DIFF
--- a/index.php
+++ b/index.php
@@ -337,7 +337,7 @@ window.onload = function () {
     scheduleReady.then(() => {
         switch (userRole) {
             case 'admin':
-                loadTable();
+                window.schedule.loadSchedule();
                 break;
             case 'manager':
                 loadForm();


### PR DESCRIPTION
## Summary
- change the admin branch of the onload handler to open the schedule view immediately

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68c85d8111e0833395d127bed3915ab8