### PR TITLE
Expose schedule selection helpers globally

### DIFF
--- a/schedules/scheduleList.js
+++ b/schedules/scheduleList.js
@@ -816,16 +816,20 @@ function renderWarehouseOptions(warehouses) {
 function selectWarehouse(warehouse) {
     window.selectedWarehouse = warehouse;
     window.activeDestinationWarehouseFilter = warehouse;
-    
+
     // Обновляем индикатор шага
     updateStepIndicator(3, true);
-    
+
     // Переходим к результатам
     goToStep(4);
-    
+
     // Загружаем результаты
     loadScheduleResults();
 }
+
+window.selectCity = selectCity;
+window.selectMarketplace = selectMarketplace;
+window.selectWarehouse = selectWarehouse;
 
 // Загрузка результатов расписания
 function loadScheduleResults() {


### PR DESCRIPTION
## Summary
- export the selectCity, selectMarketplace, and selectWarehouse handlers onto window for console access

## Testing
- not run (frontend change)

------
https://chatgpt.com/codex/tasks/task_e_68c8726db22c8333a582035ed1ecd32f