### PR TITLE
Handle invalid schedule deadlines

### DIFF
--- a/schedule.js
+++ b/schedule.js
@@ -975,8 +975,12 @@ function canCreateOrderForSchedule(schedule) {
     const deadline = schedule.accept_deadline;
     if (!deadline) return true;
 
-    const now = new Date();
     const deadlineDate = new Date(deadline);
+    if (Number.isNaN(deadlineDate.getTime())) {
+        return true;
+    }
+
+    const now = new Date();
     return now <= deadlineDate;
 }
 

--- a/schedules/scheduleList.js
+++ b/schedules/scheduleList.js
@@ -27,6 +27,22 @@ window.activeMarketplaceFilter = "";
 
 let lastRenderedSchedules = [];
 
+function canCreateOrderForSchedule(schedule) {
+    if (!schedule) return false;
+    if (schedule.status === 'Завершено' || schedule.status === 'Товар отправлен') return false;
+
+    const deadline = schedule?.accept_deadline;
+    if (!deadline) return true;
+
+    const deadlineDate = new Date(deadline);
+    if (Number.isNaN(deadlineDate.getTime())) {
+        return true;
+    }
+
+    const now = new Date();
+    return now <= deadlineDate;
+}
+
 function escapeHtmlAttribute(value) {
     if (value === null || value === undefined) return "";
     return String(value)

--- a/schedules/scheduleModal.js
+++ b/schedules/scheduleModal.js
@@ -93,8 +93,12 @@ function canCreateOrderForSchedule(schedule) {
     const deadline = schedule.accept_deadline;
     if (!deadline) return true;
 
-    const now = new Date();
     const deadlineDate = new Date(deadline);
+    if (Number.isNaN(deadlineDate.getTime())) {
+        return true;
+    }
+
+    const now = new Date();
     return now <= deadlineDate;
 }
 


### PR DESCRIPTION
## Summary
- allow canCreateOrderForSchedule to treat missing or invalid deadlines as open in the legacy schedule page
- add the same deadline validation to the modular schedule list and modal helpers so clients can still create orders when no deadline is set

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8ad2d71408333978518f9c4a04d76