### PR TITLE
Protect client panel with session

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -1,3 +1,13 @@
+<?php
+require_once __DIR__ . '/../session_init.php';
+
+session_start();
+
+if (empty($_SESSION['user_id'])) {
+    header('Location: ../auth_form.php');
+    exit;
+}
+?>
 <!DOCTYPE html>
 <html lang="ru">
 <head>

--- a/client/js/profile.js
+++ b/client/js/profile.js
@@ -19,7 +19,9 @@ class ProfileManager {
         try {
             const response = await fetch('../fetch_user_data.php', { credentials: 'include' });
             if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
+                console.error('fetch_user_data.php вернул ошибку:', response.status);
+                window.location.href = '../auth_form.php';
+                return false;
             }
 
             const data = await response.json();


### PR DESCRIPTION
## Summary
- convert the client panel entry point into a PHP script that boots the session and guards access
- reuse the shared session initialisation and redirect unauthenticated visitors to the login form
- redirect the frontend to the login form when the user data request fails

## Testing
- php -l client/index.php

------
https://chatgpt.com/codex/tasks/task_e_68c8c94cc8048333b2f2865ad4aeb597