### PR TITLE
Fix request form modal template path resolution

### DIFF
--- a/requestForm.js
+++ b/requestForm.js
@@ -27,15 +27,47 @@ async function calculateCost(schedule) {
     }
 }
 
+function resolveTemplateUrl(relativePath) {
+    if (typeof relativePath !== 'string') return relativePath;
+
+    try {
+        const currentScript = document?.currentScript;
+        if (currentScript?.src) {
+            return new URL(relativePath, currentScript.src).toString();
+        }
+
+        const scripts = document?.querySelectorAll?.('script[src]');
+        if (scripts) {
+            for (const script of scripts) {
+                if (script.src?.includes('requestForm.js')) {
+                    return new URL(relativePath, script.src).toString();
+                }
+            }
+        }
+    } catch (err) {
+        console.warn('Не удалось вычислить путь относительно скрипта requestForm.js:', err);
+    }
+
+    try {
+        return new URL(relativePath, window.location.href).toString();
+    } catch (err) {
+        console.warn('Не удалось вычислить путь относительно текущей страницы:', err);
+    }
+
+    return relativePath;
+}
+
 async function openRequestFormModal(scheduleOrId, city = "", warehouse = "", marketplace = "") {
     const schedule =
         typeof scheduleOrId === 'object'
             ? scheduleOrId
             : { id: scheduleOrId, city, warehouses: warehouse, marketplace };
 
+    const templateUrl = resolveTemplateUrl('templates/orderModal.html');
     try {
-        const tmplResp = await fetch('/client/templates/orderModal.html');
+        const tmplResp = await fetch(templateUrl);
         if (!tmplResp.ok) {
+            console.error(`Не удалось загрузить шаблон формы заявки (${templateUrl}): ${tmplResp.status} ${tmplResp.statusText}`);
             if (tmplResp.status === 404) {
                 throw new Error('Шаблон формы заявки не найден');
             }
@@ -97,6 +129,9 @@ async function openRequestFormModal(scheduleOrId, city = "", warehouse = "", mar
         }
     } catch (err) {
         console.error('Ошибка открытия формы заявки:', err);
+        if (templateUrl) {
+            console.error('Форма заявки не была открыта. Попытка загрузить шаблон по адресу:', templateUrl);
+        }
         alert(err.message || 'Не удалось открыть форму заявки');
     }
 }


### PR DESCRIPTION
## Summary
- resolve the request form template URL relative to the script or current page
- log detailed information when loading the modal template fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8cc92c3348333969fc902302efd80