### PR TITLE
Fix request form template path resolution

### DIFF
--- a/requestForm.js
+++ b/requestForm.js
@@ -73,11 +73,9 @@ async function openRequestFormModal(scheduleOrId, city = "", warehouse = "", mar
             ? scheduleOrId
             : { id: scheduleOrId, city, warehouses: warehouse, marketplace };
     const relativeTemplatePath = window.location.pathname.includes('/client/')
-        ? 'templates/orderModal.html'
-        : 'client/templates/orderModal.html';
+        ? 'client/templates/orderModal.html'
+        : 'templates/orderModal.html';
     const templateUrl = resolveTemplateUrl(relativeTemplatePath);
-
-    const templateUrl = resolveTemplateUrl('templates/orderModal.html');
     try {
         const tmplResp = await fetch(templateUrl);
         if (!tmplResp.ok) {


### PR DESCRIPTION
## Summary
- correct the request form modal template path resolution based on client routes
- remove the duplicate templateUrl declaration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d8833bcc8333ad91335527683935