### PR TITLE
Fix client template path for request form modal

### DIFF
--- a/requestForm.js
+++ b/requestForm.js
@@ -73,7 +73,7 @@ async function openRequestFormModal(scheduleOrId, city = "", warehouse = "", mar
             ? scheduleOrId
             : { id: scheduleOrId, city, warehouses: warehouse, marketplace };
     const relativeTemplatePath = window.location.pathname.includes('/client/')
-        ? 'client/templates/orderModal.html'
+        ? '/client/templates/orderModal.html'
         : 'templates/orderModal.html';
     const templateUrl = resolveTemplateUrl(relativeTemplatePath);
     try {


### PR DESCRIPTION
## Summary
- update the client request form modal template path to use an absolute `/client/...` location when on client pages
- keep template URL resolution working with the corrected path to avoid duplicate `/client/` segments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8da6ac3748333945572698214d721