### PR TITLE
Fix tariff fetch path in request form

### DIFF
--- a/requestForm.js
+++ b/requestForm.js
@@ -10,7 +10,7 @@ async function calculateCost(schedule) {
 
     try {
         const resp = await fetch(
-            `get_tariff.php?city=${encodeURIComponent(schedule.city)}&warehouse=${encodeURIComponent(warehouseName)}`
+            `/get_tariff.php?city=${encodeURIComponent(schedule.city)}&warehouse=${encodeURIComponent(warehouseName)}`
         );
         const data = await resp.json();
         if (!data.success) return 0;


### PR DESCRIPTION
## Summary
- switch the tariff request in `requestForm.js` to use an absolute `/get_tariff.php` URL so it works regardless of the current page location

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9361a2f308333af7c722fc2ce8981