### PR TITLE
Исправить путь для create_order.php в форме заявки

### DIFF
--- a/requestForm.js
+++ b/requestForm.js
@@ -188,7 +188,9 @@ function submitOrderForm(e) {
         items
     };
 
-    fetch('create_order.php', {
+    const createOrderUrl = resolveTemplateUrl('/create_order.php');
+
+    fetch(createOrderUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- использовать resolveTemplateUrl, чтобы запрос create_order.php формировался как абсолютный путь и корректно работал из каталога /client/

## Testing
- вручную отправил заявку из client/index.php (Playwright-скрипт), убедился по логам PHP-сервера, что пришёл POST /create_order.php

------
https://chatgpt.com/codex/tasks/task_e_68c9606bd1c48333b98febf2a07c9698