### PR TITLE
Fix request modal visibility classes

### DIFF
--- a/requestForm.js
+++ b/requestForm.js
@@ -308,7 +308,7 @@ async function openRequestFormModal(scheduleOrId, city = "", warehouse = "", mar
     const closeModal = () => {
         if (closed) return;
         closed = true;
-        modal.classList.remove('active');
+        modal.classList.remove('active', 'show');
         modal.style.display = 'none';
         if (contentHost) {
             contentHost.innerHTML = '';
@@ -336,7 +336,7 @@ async function openRequestFormModal(scheduleOrId, city = "", warehouse = "", mar
     document.addEventListener('keydown', escHandler);
     modal._legacyCleanup = closeModal;
 
-    modal.classList.add('active');
+    modal.classList.add('active', 'show');
     modal.style.display = 'flex';
     document.body.classList.add('modal-open');
 


### PR DESCRIPTION
## Summary
- ensure the request modal adds both `active` and `show` classes when opened and forces flex display
- remove both classes and hide the modal on close to keep content clearing working

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9a046a408833399f418327558e1c2