### PR TITLE
Expose initializeForm globally

### DIFF
--- a/form.js
+++ b/form.js
@@ -908,4 +908,6 @@ function initializeForm() {
 
 
 
+window.initializeForm = initializeForm;
+
 initializeForm();


### PR DESCRIPTION
## Summary
- expose initializeForm via window so it can be reused after lazy-loading the form script

## Testing
- npm install
- npm run build *(fails: Vite could not resolve entry module "index.html" in client project)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a7a479388333af8ef3b882ceb2b7