### PR TITLE
Support dedicated client request modal

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -304,6 +304,10 @@ if (empty($_SESSION['user_id'])) {
         </div>
     </div>
 
+    <div class="modal" id="clientRequestModal">
+        <div class="modal-content" id="clientRequestModalContent"></div>
+    </div>
+
     <!-- Уведомления -->
     <div class="notifications-panel" id="notificationsPanel">
         <div class="notifications-header">

--- a/client/js/orders.js
+++ b/client/js/orders.js
@@ -11,8 +11,15 @@ class OrdersManager {
         this.setupTabs();
         const btn = document.getElementById('createOrderBtn');
         btn?.addEventListener('click', () => {
-            if (typeof window.openRequestFormModal === 'function') {
-                window.openRequestFormModal({});
+            if (typeof window.openClientRequestFormModal === 'function') {
+                window.openClientRequestFormModal({});
+            } else if (typeof window.openRequestFormModal === 'function') {
+                window.openRequestFormModal({}, '', '', '', {
+                    modalId: 'clientRequestModal',
+                    contentId: 'clientRequestModalContent'
+                });
+            } else {
+                console.error('openRequestFormModal is not loaded');
             }
         });
         this.loadOrders();

--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -599,8 +599,13 @@ class ScheduleManager {
             window.app.closeModal(detailsModal);
         }
 
-        if (typeof window.openRequestFormModal === 'function') {
-            window.openRequestFormModal(schedule);
+        if (typeof window.openClientRequestFormModal === 'function') {
+            window.openClientRequestFormModal(schedule);
+        } else if (typeof window.openRequestFormModal === 'function') {
+            window.openRequestFormModal(schedule, '', '', '', {
+                modalId: 'clientRequestModal',
+                contentId: 'clientRequestModalContent'
+            });
         } else {
             console.error('openRequestFormModal is not loaded');
             if (window.app && typeof window.app.showError === 'function') {


### PR DESCRIPTION
## Summary
- allow configuring request form modal/container ids and record the last modal id
- extend `openRequestFormModal` with options/callbacks and expose a client-specific helper
- update client UI to open the dedicated client request modal and provide its markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9aeffbd0483338d8cc99537602270