### PR TITLE
Fix resolveFormPath catch block

### DIFF
--- a/form.js
+++ b/form.js
@@ -49,30 +49,6 @@ function resolveFormPath(relativePath) {
         return new URL(relativePath, window.location.href).toString();
     } catch (err) {
         console.warn('resolveFormPath: не удалось вычислить путь относительно страницы', err);
-
-    if (typeof relativePath !== 'string') return relativePath;
-
-    try {
-        return new URL(relativePath, window.location.href).toString();
-    } catch (err) {
-        console.warn('resolveFormPath: не удалось вычислить путь относительно страницы', err);
-    }
-
-    try {
-        const currentScript = document?.currentScript;
-        if (currentScript?.src) {
-            return new URL(relativePath, currentScript.src).toString();
-        }
-        const scripts = document?.querySelectorAll?.('script[src]');
-        if (scripts) {
-            for (const script of scripts) {
-                if (script.src?.includes('form.js')) {
-                    return new URL(relativePath, script.src).toString();
-                }
-            }
-        }
-    } catch (err) {
-        console.warn('resolveFormPath: не удалось вычислить путь относительно form.js', err);
     }
 
     return relativePath;


### PR DESCRIPTION
## Summary
- close the final catch in resolveFormPath to avoid syntax issues
- remove duplicated fallback logic after the catch and rely on the early guards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d56d23c08333962399b36ec1d975