### PR TITLE
Refine schedule form action layouts

### DIFF
--- a/schedule/index.js
+++ b/schedule/index.js
@@ -547,7 +547,7 @@ function showCreateForm() {
                 <form id="createScheduleForm">
                     <div class="form-group">
                         <label>Город отправления:</label>
-                        <div class="modal-inline-row">
+                        <div class="modal-inline-row city-actions">
                             <select name="city" id="citySelect" required>
                                 ${cities.map(c => `<option value="${c.id}">${c.name}</option>`).join("")}
                             </select>
@@ -598,7 +598,7 @@ function showCreateForm() {
                               `).join("")
                             }
                         </div>
-                        <div class="modal-inline-actions">
+                        <div class="modal-inline-actions warehouse-actions">
                             <button
                                 type="button"
                                 class="primary-button modal-action-button"
@@ -627,7 +627,7 @@ function showCreateForm() {
                                 <span class="modal-action-button__text">Удалить склады</span>
                             </button>
                         </div>
-                        <div id="warehouseEditControls" class="modal-inline-actions" style="display:none;">
+                        <div id="warehouseEditControls" class="modal-inline-actions warehouse-edit-controls">
                             <button
                                 type="button"
                                 class="primary-button modal-action-button"

--- a/schedule/warehouses.js
+++ b/schedule/warehouses.js
@@ -44,7 +44,7 @@ export function enterWarehouseEditMode() {
 
     const controls = document.getElementById('warehouseEditControls');
     if (controls) {
-        controls.style.display = 'block';
+        controls.classList.add('is-visible');
     }
 }
 
@@ -61,7 +61,7 @@ export function cancelWarehouseEdits() {
 
     const controls = document.getElementById('warehouseEditControls');
     if (controls) {
-        controls.style.display = 'none';
+        controls.classList.remove('is-visible');
     }
 }
 

--- a/styles/schedule.css
+++ b/styles/schedule.css
@@ -478,6 +478,69 @@
     margin-top: 8px;
 }
 
+.city-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    width: 100%;
+}
+
+.city-actions select {
+    flex: 1 1 240px;
+    min-width: 180px;
+}
+
+.warehouse-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 8px;
+    align-items: center;
+    width: 100%;
+}
+
+.warehouse-actions .modal-action-button,
+.warehouse-edit-controls .modal-action-button {
+    flex: 0 1 auto;
+}
+
+.warehouse-edit-controls {
+    display: none;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 8px;
+    align-items: center;
+    width: 100%;
+}
+
+.warehouse-edit-controls.is-visible {
+    display: flex;
+}
+
+@media (max-width: 640px) {
+    .city-actions {
+        align-items: stretch;
+    }
+
+    .city-actions select {
+        flex-basis: 100%;
+        min-width: 0;
+    }
+
+    .city-actions .modal-action-button,
+    .warehouse-actions .modal-action-button,
+    .warehouse-edit-controls .modal-action-button {
+        flex: 1 1 100%;
+        width: 100%;
+    }
+
+    .warehouse-actions,
+    .warehouse-edit-controls {
+        align-items: stretch;
+    }
+}
+
 .modal-action-button {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add semantic wrappers for the city picker and warehouse action areas in the schedule creation modal
- add responsive styling for the new layout helper classes and the edit controls visibility state
- switch warehouse edit controls to use a CSS visibility class instead of inline styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca05b4935c8333bde0ad2f427b3f16