### PR TITLE
Refine request modal summary display

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -4,11 +4,6 @@
   gap: 8px;
 }
 
-.request-form__static-field {
-  text-align: center;
-  font-weight: 600;
-}
-
 .request-form__radio-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/client/templates/customOrderModal.html
+++ b/client/templates/customOrderModal.html
@@ -15,14 +15,16 @@
         <input type="hidden" name="accept_time" id="acceptTimeField" value="">
         <input type="hidden" name="direction" id="directionField" value="">
 
-        <div class="form-group request-form__group">
-          <label>Направление:</label>
-          <div class="static-field request-modal__static-field request-form__static-field" id="legacyDirection">—</div>
-        </div>
+        <div class="request-modal__summary">
+          <div class="modal-row request-modal__summary-row">
+            <span class="modal-label">Направление:</span>
+            <span class="modal-value" id="legacyDirection">—</span>
+          </div>
 
-        <div class="form-group request-form__group">
-          <label>Выезд → Сдача:</label>
-          <div class="static-field request-modal__static-field request-form__static-field" id="legacyDates">—</div>
+          <div class="modal-row request-modal__summary-row">
+            <span class="modal-label">Выезд → Сдача:</span>
+            <span class="modal-value" id="legacyDates">—</span>
+          </div>
         </div>
 
         <input type="hidden" id="city" name="city" value="">

--- a/form.js
+++ b/form.js
@@ -117,14 +117,16 @@ function renderFormHTML(scheduleData = {}) {
         <input type="hidden" name="accept_time" id="acceptTimeField" value="${accept_time}">
         <input type="hidden" name="direction" id="directionField" value="${warehouses}">
 
-        <div class="form-group request-form__group">
-          <label>Направление:</label>
-          <div class="static-field request-modal__static-field request-form__static-field">${city || '—'} → ${warehouses || '—'}</div>
-        </div>
+        <div class="request-modal__summary">
+          <div class="modal-row request-modal__summary-row">
+            <span class="modal-label">Направление:</span>
+            <span class="modal-value">${city || '—'} → ${warehouses || '—'}</span>
+          </div>
 
-        <div class="form-group request-form__group">
-          <label>Выезд → Сдача:</label>
-          <div class="static-field request-modal__static-field request-form__static-field">${combinedDates || '—'}</div>
+          <div class="modal-row request-modal__summary-row">
+            <span class="modal-label">Выезд → Сдача:</span>
+            <span class="modal-value">${combinedDates || '—'}</span>
+          </div>
         </div>
 
         <input type="hidden" id="city" name="city" value="${city}">

--- a/styles/components.css
+++ b/styles/components.css
@@ -384,18 +384,40 @@
     text-align: left;
 }
 
-.request-modal .static-field {
-    display: block;
-    width: 100%;
-    padding: 0.625rem 0.875rem;
-    margin-top: 0.25rem;
+
+.request-modal__summary {
     border: 1px solid var(--request-modal-border);
-    border-radius: 0.5rem;
-    background: linear-gradient(180deg, rgba(255,255,255,0.95), rgba(244, 249, 246, 0.95));
+    border-radius: 0.75rem;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 249, 246, 0.92));
+    overflow: hidden;
+}
+
+.request-modal .modal-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: clamp(0.75rem, 3vw, 1.75rem);
+    flex-wrap: wrap;
+    padding: 0.75rem 1rem;
+}
+
+.request-modal .modal-row + .modal-row {
+    border-top: 1px solid var(--request-modal-border);
+}
+
+.request-modal .modal-label {
+    color: var(--request-modal-muted);
+    font-weight: 600;
+    flex: 1;
+    min-width: min(50%, 160px);
+}
+
+.request-modal .modal-value {
     color: var(--request-modal-accent);
     font-weight: 600;
-    text-align: center;
-    letter-spacing: 0.01em;
+    text-align: right;
+    flex: 1 1 40%;
+    word-break: break-word;
 }
 
 .request-modal__option-group {


### PR DESCRIPTION
## Summary
- replace legacy static summary blocks in the custom order modal with modal-row markup
- restyle request modal summary rows to match other modals and drop obsolete static-field rules
- update inline form rendering to emit the new structure for direction/date values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca1732eec48333a91000fd444d9edf