### PR TITLE
Adjust client request modal sizing

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -5,6 +5,29 @@
     --modal-timing: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+#clientRequestModal .modal-content {
+    width: min(960px, 95vw);
+    max-width: none;
+    max-height: 95vh;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+#clientRequestModal .modal-content > .request-modal {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#clientRequestModal .request-modal__body {
+    padding: clamp(16px, 3vw, 28px);
+    flex: 1;
+    max-height: none;
+    overflow-y: auto;
+}
+
 #clientRequestModal.active {
     animation: clientModalShow 0.6s var(--modal-timing) forwards;
 }


### PR DESCRIPTION
## Summary
- override the client request modal container to use a wider responsive width and remove extra outer spacing
- allow the request modal body to flex within the taller viewport height while keeping scroll behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca8fda337c8333876d76e5c7a88e5e