### PR TITLE
Обновить стили заголовка модального окна клиента

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -21,6 +21,50 @@
     height: 100%;
 }
 
+#clientRequestModal .modal-header-with-close {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: clamp(12px, 2vw, 20px);
+    padding: clamp(20px, 3vw, 28px) clamp(24px, 4vw, 32px) clamp(12px, 2vw, 20px);
+    border-bottom: 1px solid var(--border, #e5e7eb);
+    position: relative;
+}
+
+#clientRequestModal .modal-close-btn {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: var(--bg-tertiary, #f3f4f6);
+    color: var(--text-secondary, #6b7280);
+    cursor: pointer;
+    font-size: 1.75rem;
+    line-height: 1;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.12);
+}
+
+#clientRequestModal .modal-close-btn:hover {
+    background: var(--primary, #28C76F);
+    color: #ffffff;
+    transform: translateY(-1px) scale(1.03);
+    box-shadow: 0 8px 20px rgba(40, 199, 111, 0.3);
+}
+
+#clientRequestModal .modal-close-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px rgba(40, 199, 111, 0.25);
+}
+
+#clientRequestModal .modal-close-btn:active {
+    transform: scale(0.94);
+}
+
 #clientRequestModal .request-modal__body {
     padding: clamp(16px, 3vw, 28px);
     flex: 1;


### PR DESCRIPTION
## Summary
- оформить заголовок клиентского модального окна как flex-контейнер с выравниванием и адаптивными отступами
- придать кнопке закрытия современный вид и обеспечить автоматический отступ слева

## Testing
- not run (css change)

------
https://chatgpt.com/codex/tasks/task_e_68ca9121c458833392b16d5f534c948e