### PR TITLE
Redesign marketplace and warehouse selection flow

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -98,16 +98,26 @@ if (empty($_SESSION['user_id'])) {
                                     <p class="filter-step-description">Выберите площадку отправки</p>
                                 </div>
                             </div>
-                            <button class="filter-step-action" type="button" data-target="marketplaceFilter">
+                            <button class="filter-step-action" type="button" data-target="marketplaceGrid">
                                 <i class="fas fa-store"></i>
                                 Сменить маркетплейс
                             </button>
                         </div>
-                        <div class="filter-group">
-                            <label for="marketplaceFilter">Маркетплейс</label>
-                            <select id="marketplaceFilter">
-                                <option value="">Все</option>
-                            </select>
+                        <div class="filter-step-body">
+                            <div class="selection-banner" id="marketplaceBanner" data-state="active">
+                                <div class="selection-banner__icon">
+                                    <i class="fas fa-store"></i>
+                                </div>
+                                <div class="selection-banner__content">
+                                    <h4 class="selection-banner__title" data-banner-title>Выберите маркетплейс</h4>
+                                    <p class="selection-banner__description" data-banner-description>
+                                        Мы покажем подходящие склады и расписание после выбора площадки.
+                                    </p>
+                                </div>
+                                <div class="selection-banner__status" data-banner-status>Шаг 1 из 2</div>
+                            </div>
+
+                            <div class="selection-grid" id="marketplaceGrid" role="list"></div>
                         </div>
                     </div>
                     <div class="filter-step">
@@ -119,16 +129,26 @@ if (empty($_SESSION['user_id'])) {
                                     <p class="filter-step-description">Уточните точку приёма</p>
                                 </div>
                             </div>
-                            <button class="filter-step-action" type="button" data-target="warehouseFilter">
+                            <button class="filter-step-action" type="button" data-target="warehouseGrid">
                                 <i class="fas fa-warehouse"></i>
                                 Выбрать склад
                             </button>
                         </div>
-                        <div class="filter-group">
-                            <label for="warehouseFilter">Склад</label>
-                            <select id="warehouseFilter">
-                                <option value="">Все</option>
-                            </select>
+                        <div class="filter-step-body">
+                            <div class="selection-banner" id="warehouseBanner" data-state="locked">
+                                <div class="selection-banner__icon">
+                                    <i class="fas fa-warehouse"></i>
+                                </div>
+                                <div class="selection-banner__content">
+                                    <h4 class="selection-banner__title" data-banner-title>Сначала выберите маркетплейс</h4>
+                                    <p class="selection-banner__description" data-banner-description>
+                                        После выбора площадки мы покажем доступные склады и расписание приёмок.
+                                    </p>
+                                </div>
+                                <div class="selection-banner__status" data-banner-status>Шаг 2 из 2</div>
+                            </div>
+
+                            <div class="selection-grid selection-grid--warehouses" id="warehouseGrid" role="list"></div>
                         </div>
                     </div>
                 </div>

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -455,6 +455,340 @@ select.schedule-filter--highlight,
     cursor: not-allowed;
 }
 
+.filter-step-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.selection-banner {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 18px 20px;
+    border-radius: var(--radius-lg);
+    background: linear-gradient(115deg, rgba(37, 99, 235, 0.9) 0%, rgba(59, 130, 246, 0.8) 100%);
+    color: white;
+    overflow: hidden;
+    box-shadow: var(--shadow-md);
+    isolation: isolate;
+}
+
+.selection-banner::before {
+    content: '';
+    position: absolute;
+    inset: -40% -20%;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.45), transparent 60%),
+        radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.3), transparent 55%);
+    opacity: 0.8;
+    transform: rotate(6deg) scale(1.1);
+    animation: bannerWave 16s ease-in-out infinite;
+    z-index: -1;
+}
+
+.selection-banner__icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.35rem;
+    color: inherit;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+    transition: transform 0.4s ease, background 0.4s ease;
+}
+
+.selection-banner__content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.selection-banner__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+}
+
+.selection-banner__description {
+    font-size: 0.9rem;
+    font-weight: 500;
+    opacity: 0.9;
+}
+
+.selection-banner__status {
+    margin-left: auto;
+    align-self: flex-start;
+    padding: 8px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.2);
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.selection-banner[data-state="locked"],
+.selection-banner[data-state="empty"] {
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    box-shadow: inset 0 0 0 1px rgba(107, 114, 128, 0.15);
+}
+
+.selection-banner[data-state="locked"]::before,
+.selection-banner[data-state="empty"]::before {
+    opacity: 0;
+    animation: none;
+}
+
+.selection-banner[data-state="locked"] .selection-banner__status,
+.selection-banner[data-state="empty"] .selection-banner__status {
+    background: rgba(17, 24, 39, 0.08);
+    color: inherit;
+}
+
+.selection-banner[data-state="empty"] {
+    border: 1px dashed rgba(245, 158, 11, 0.35);
+}
+
+.selection-banner[data-state="complete"] {
+    background: linear-gradient(115deg, rgba(16, 185, 129, 0.95) 0%, rgba(5, 150, 105, 0.9) 100%);
+}
+
+.selection-banner[data-state="complete"]::before {
+    animation-duration: 20s;
+    opacity: 0.9;
+}
+
+.selection-banner[data-state="complete"] .selection-banner__status {
+    background: rgba(255, 255, 255, 0.25);
+}
+
+.selection-banner[data-state="locked"] .selection-banner__icon,
+.selection-banner[data-state="empty"] .selection-banner__icon {
+    background: rgba(17, 24, 39, 0.05);
+    color: var(--text-secondary);
+    box-shadow: none;
+}
+
+.selection-banner[data-state="active"] .selection-banner__icon {
+    transform: rotate(-6deg) scale(1.02);
+}
+
+.selection-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    transition: var(--transition);
+}
+
+.selection-grid--warehouses {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.selection-grid[data-state="locked"] {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.selection-grid[data-state="empty"] {
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+}
+
+.selection-skeleton {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    width: 100%;
+}
+
+.selection-skeleton__pulse {
+    height: 120px;
+    border-radius: var(--radius-lg);
+    background: linear-gradient(90deg, rgba(229, 231, 235, 0.8) 0%, rgba(209, 213, 219, 0.6) 50%, rgba(229, 231, 235, 0.8) 100%);
+    background-size: 200% 100%;
+    animation: skeletonPulse 1.4s ease-in-out infinite;
+}
+
+.selection-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+    padding: 18px 20px;
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(203, 213, 225, 0.8);
+    background: white;
+    color: var(--text-primary);
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+    text-align: left;
+    min-height: 132px;
+}
+
+.selection-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    border-color: rgba(37, 99, 235, 0.35);
+}
+
+.selection-card__abbr {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--secondary);
+    font-weight: 700;
+    font-size: 0.95rem;
+}
+
+.selection-card__title {
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+}
+
+.selection-card__meta {
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--secondary);
+}
+
+.selection-card__description {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+.selection-card__check {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--primary);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    opacity: 0;
+    transform: scale(0.8);
+    transition: var(--transition);
+    box-shadow: 0 8px 16px -4px rgba(40, 199, 111, 0.45);
+}
+
+.selection-card--selected {
+    border-color: rgba(37, 99, 235, 0.6);
+    box-shadow: 0 10px 24px -12px rgba(37, 99, 235, 0.5);
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08) 0%, rgba(59, 130, 246, 0.05) 100%);
+}
+
+.selection-card--selected .selection-card__abbr {
+    background: rgba(37, 99, 235, 0.18);
+    color: rgba(37, 99, 235, 0.95);
+}
+
+.selection-card--selected .selection-card__check {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.selection-card--disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    background: var(--bg-secondary);
+    border-style: dashed;
+}
+
+.selection-card--disabled .selection-card__abbr {
+    background: rgba(107, 114, 128, 0.15);
+    color: var(--text-light);
+}
+
+.selection-card--warehouse .selection-card__abbr {
+    background: rgba(40, 199, 111, 0.12);
+    color: var(--success);
+}
+
+.selection-card--warehouse.selection-card--selected {
+    border-color: rgba(16, 185, 129, 0.6);
+    box-shadow: 0 10px 24px -12px rgba(16, 185, 129, 0.5);
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.12) 0%, rgba(45, 212, 191, 0.1) 100%);
+}
+
+.selection-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    text-align: center;
+    padding: 32px 24px;
+    border-radius: var(--radius-lg);
+    background: white;
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+    color: var(--text-secondary);
+    min-height: 140px;
+    box-shadow: var(--shadow-sm);
+}
+
+.selection-empty i {
+    font-size: 1.6rem;
+    color: rgba(37, 99, 235, 0.5);
+}
+
+.selection-empty span {
+    font-size: 0.82rem;
+}
+
+.selection-grid.schedule-filter--highlight,
+.selection-banner.schedule-filter--highlight {
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.schedule-grid.schedule-filter--highlight {
+    box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.25);
+    border-radius: var(--radius-lg);
+}
+
+@keyframes bannerWave {
+    0% {
+        transform: rotate(6deg) scale(1.05);
+    }
+    50% {
+        transform: rotate(0deg) scale(1.1);
+    }
+    100% {
+        transform: rotate(6deg) scale(1.05);
+    }
+}
+
+@keyframes skeletonPulse {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
 /* Schedule Grid */
 .schedule-grid {
     display: grid;


### PR DESCRIPTION
## Summary
- replace the step 1–2 select blocks with banner prompts and card grids on the schedule page
- render marketplace and warehouse cards with dynamic states, banner messaging and auto step transitions in the scheduler script
- style the new banners, skeleton loader and card states including animations and highlight effects

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68cb1496e6708333950ef53d7f5c3600