### PR TITLE
feat: обновить пошаговый интерфейс расписания

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -78,100 +78,145 @@ if (empty($_SESSION['user_id'])) {
         <section class="content-section active" id="scheduleSection">
             <div class="section-header">
                 <h2>Расписание отправлений</h2>
-                <p>Выберите подходящее расписание для создания заявки</p>
-            </div>
-            
-            <div class="schedule-tabs">
-                <button class="tab-btn active" data-tab="upcoming">Ближайшие</button>
-                <button class="tab-btn" data-tab="calendar">Календарь</button>
+                <p>Пошаговый выбор: маркетплейс → склад → дата отправления</p>
             </div>
 
-            <!-- Вкладка ближайших отправлений -->
-            <div class="tab-content active" id="upcomingTab">
-                <div class="filters">
-                    <div class="filter-step">
-                        <div class="filter-step-header">
-                            <div class="filter-step-info">
-                                <span class="filter-step-number">Шаг 1</span>
-                                <div>
-                                    <h3 class="filter-step-title">Маркетплейс</h3>
-                                    <p class="filter-step-description">Выберите площадку отправки</p>
-                                </div>
-                            </div>
-                            <button class="filter-step-action" type="button" data-target="marketplaceGrid">
+            <div class="step-wizard" data-progress="1">
+                <div class="step-indicators">
+                    <div class="step-indicator active" data-step="1">
+                        <div class="step-circle">
+                            <span class="step-number">1</span>
+                            <i class="fas fa-check step-check"></i>
+                        </div>
+                        <span class="step-label">Маркетплейс</span>
+                    </div>
+                    <div class="step-line"></div>
+                    <div class="step-indicator" data-step="2">
+                        <div class="step-circle">
+                            <span class="step-number">2</span>
+                            <i class="fas fa-check step-check"></i>
+                        </div>
+                        <span class="step-label">Склад</span>
+                    </div>
+                    <div class="step-line"></div>
+                    <div class="step-indicator" data-step="3">
+                        <div class="step-circle">
+                            <span class="step-number">3</span>
+                            <i class="fas fa-check step-check"></i>
+                        </div>
+                        <span class="step-label">Расписание</span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="steps-container">
+                <div class="step-content active" id="step1">
+                    <div class="step-card">
+                        <div class="step-header">
+                            <h3>
                                 <i class="fas fa-store"></i>
-                                Сменить маркетплейс
-                            </button>
+                                Выберите маркетплейс
+                            </h3>
+                            <p>Укажите площадку, на которой оформляете отправку</p>
                         </div>
-                        <div class="filter-step-body">
-                            <div class="selection-banner" id="marketplaceBanner" data-state="active">
-                                <div class="selection-banner__icon">
-                                    <i class="fas fa-store"></i>
-                                </div>
-                                <div class="selection-banner__content">
-                                    <h4 class="selection-banner__title" data-banner-title>Выберите маркетплейс</h4>
-                                    <p class="selection-banner__description" data-banner-description>
-                                        Мы покажем подходящие склады и расписание после выбора площадки.
-                                    </p>
-                                </div>
-                                <div class="selection-banner__status" data-banner-status>Шаг 1 из 2</div>
-                            </div>
 
-                            <div class="selection-grid" id="marketplaceGrid" role="list"></div>
-                        </div>
-                    </div>
-                    <div class="filter-step">
-                        <div class="filter-step-header">
-                            <div class="filter-step-info">
-                                <span class="filter-step-number">Шаг 2</span>
-                                <div>
-                                    <h3 class="filter-step-title">Склад</h3>
-                                    <p class="filter-step-description">Уточните точку приёма</p>
-                                </div>
+                        <div class="selection-banner" id="marketplaceBanner" data-state="active">
+                            <div class="selection-banner__icon">
+                                <i class="fas fa-store"></i>
                             </div>
-                            <button class="filter-step-action" type="button" data-target="warehouseGrid">
-                                <i class="fas fa-warehouse"></i>
-                                Выбрать склад
-                            </button>
-                        </div>
-                        <div class="filter-step-body">
-                            <div class="selection-banner" id="warehouseBanner" data-state="locked">
-                                <div class="selection-banner__icon">
-                                    <i class="fas fa-warehouse"></i>
-                                </div>
-                                <div class="selection-banner__content">
-                                    <h4 class="selection-banner__title" data-banner-title>Сначала выберите маркетплейс</h4>
-                                    <p class="selection-banner__description" data-banner-description>
-                                        После выбора площадки мы покажем доступные склады и расписание приёмок.
-                                    </p>
-                                </div>
-                                <div class="selection-banner__status" data-banner-status>Шаг 2 из 2</div>
+                            <div class="selection-banner__content">
+                                <h4 class="selection-banner__title" data-banner-title>Выберите маркетплейс</h4>
+                                <p class="selection-banner__description" data-banner-description>
+                                    После выбора площадки мы покажем подходящие склады и даты отправлений.
+                                </p>
                             </div>
+                            <div class="selection-banner__status" data-banner-status>Шаг 1 из 3</div>
+                        </div>
 
-                            <div class="selection-grid selection-grid--warehouses" id="warehouseGrid" role="list"></div>
+                        <div class="selection-grid marketplace-grid" id="marketplaceGrid" role="list">
+                            <div class="loading">
+                                <div class="spinner"></div>
+                                Загрузка маркетплейсов...
+                            </div>
                         </div>
                     </div>
                 </div>
 
-                <div class="schedule-grid" id="scheduleGrid">
-                    <!-- Карточки расписания будут генерироваться динамически -->
+                <div class="step-content" id="step2">
+                    <div class="step-card">
+                        <div class="step-header">
+                            <h3>
+                                <i class="fas fa-warehouse"></i>
+                                Выберите склад назначения
+                            </h3>
+                            <p>Доступные склады для маркетплейса <span id="selectedMarketplace">—</span></p>
+                        </div>
+
+                        <div class="selection-banner" id="warehouseBanner" data-state="locked">
+                            <div class="selection-banner__icon">
+                                <i class="fas fa-warehouse"></i>
+                            </div>
+                            <div class="selection-banner__content">
+                                <h4 class="selection-banner__title" data-banner-title>Сначала выберите маркетплейс</h4>
+                                <p class="selection-banner__description" data-banner-description>
+                                    Как только выберете площадку, мы подгрузим доступные склады.
+                                </p>
+                            </div>
+                            <div class="selection-banner__status" data-banner-status>Шаг 2 из 3</div>
+                        </div>
+
+                        <div class="selection-grid warehouse-grid" id="warehouseGrid" role="list"></div>
+                    </div>
+                </div>
+
+                <div class="step-content" id="step3">
+                    <div class="step-card">
+                        <div class="step-header">
+                            <h3>
+                                <i class="fas fa-calendar-alt"></i>
+                                Расписание отправлений
+                            </h3>
+                            <p id="scheduleStepSubtitle">Чтобы увидеть расписание, выберите маркетплейс и склад</p>
+                        </div>
+
+                        <div class="step-summary">
+                            <span class="summary-pill" id="summaryMarketplace">Маркетплейс: —</span>
+                            <span class="summary-pill" id="summaryWarehouse">Склад: —</span>
+                        </div>
+
+                        <div class="schedule-step-layout">
+                            <div class="schedule-grid" id="scheduleGrid"></div>
+
+                            <div class="calendar-panel">
+                                <div class="calendar-controls">
+                                    <button class="calendar-nav" id="prevMonth">
+                                        <i class="fas fa-chevron-left"></i>
+                                    </button>
+                                    <h3 id="currentMonth">Январь 2025</h3>
+                                    <button class="calendar-nav" id="nextMonth">
+                                        <i class="fas fa-chevron-right"></i>
+                                    </button>
+                                </div>
+                                <div class="calendar-grid" id="calendarGrid"></div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 
-            <!-- Вкладка календаря -->
-            <div class="tab-content" id="calendarTab">
-                <div class="calendar-controls">
-                    <button class="calendar-nav" id="prevMonth">
-                        <i class="fas fa-chevron-left"></i>
-                    </button>
-                    <h3 id="currentMonth">Январь 2025</h3>
-                    <button class="calendar-nav" id="nextMonth">
-                        <i class="fas fa-chevron-right"></i>
-                    </button>
-                </div>
-                <div class="calendar-grid" id="calendarGrid">
-                    <!-- Календарь генерируется динамически -->
-                </div>
+            <div class="step-navigation">
+                <button class="step-nav-btn secondary" id="stepBackBtn" style="display: none;">
+                    <i class="fas fa-arrow-left"></i>
+                    Назад
+                </button>
+                <button class="step-nav-btn primary" id="stepNextBtn" style="display: none;">
+                    Далее
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+                <button class="step-nav-btn ghost" id="resetStepsBtn">
+                    <i class="fas fa-rotate-right"></i>
+                    Сбросить выбор
+                </button>
             </div>
         </section>
 

--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -14,6 +14,10 @@ class ScheduleManager {
         this.marketplaceOptions = [];
         this.warehouseOptions = [];
         this.calendarData = {};
+        this.isLoadingMarketplaces = false;
+        this.isLoadingWarehouses = false;
+        this.isLoadingSchedules = false;
+        this.schedulesCache = new Map();
 
         this.init();
     }
@@ -21,8 +25,13 @@ class ScheduleManager {
     init() {
         this.setupStepNavigation();
         this.setupCalendarControls();
+        this.updateMarketplaceBanner();
+        this.updateWarehouseBanner();
+        this.updateSelectionSummary();
         this.loadMarketplaces();
         this.showStep(1);
+        this.renderScheduleGrid();
+        this.renderCalendar();
     }
 
     setupStepNavigation() {
@@ -66,9 +75,106 @@ class ScheduleManager {
         }
     }
 
+    setBannerState(bannerId, { state = 'active', title = '', description = '', status = '' } = {}) {
+        const banner = document.getElementById(bannerId);
+        if (!banner) return;
+
+        banner.dataset.state = state;
+
+        const titleEl = banner.querySelector('[data-banner-title]');
+        if (titleEl) {
+            titleEl.textContent = title;
+        }
+
+        const descriptionEl = banner.querySelector('[data-banner-description]');
+        if (descriptionEl) {
+            descriptionEl.textContent = description;
+        }
+
+        const statusEl = banner.querySelector('[data-banner-status]');
+        if (statusEl) {
+            statusEl.textContent = status;
+        }
+    }
+
+    updateMarketplaceBanner() {
+        if (this.filters.marketplace) {
+            this.setBannerState('marketplaceBanner', {
+                state: 'completed',
+                title: `Выбран маркетплейс «${this.filters.marketplace}»`,
+                description: 'Можно перейти к следующему шагу и выбрать склад.',
+                status: 'Готово ✓'
+            });
+        } else {
+            this.setBannerState('marketplaceBanner', {
+                state: 'active',
+                title: 'Выберите маркетплейс',
+                description: 'После выбора площадки мы покажем подходящие склады и даты отправлений.',
+                status: 'Шаг 1 из 3'
+            });
+        }
+    }
+
+    updateWarehouseBanner() {
+        if (!this.filters.marketplace) {
+            this.setBannerState('warehouseBanner', {
+                state: 'locked',
+                title: 'Сначала выберите маркетплейс',
+                description: 'Как только выберете площадку, мы подгрузим доступные склады.',
+                status: 'Шаг 2 из 3'
+            });
+            return;
+        }
+
+        if (this.filters.warehouse) {
+            this.setBannerState('warehouseBanner', {
+                state: 'completed',
+                title: `Выбран склад «${this.filters.warehouse}»`,
+                description: 'Осталось выбрать дату отправления на следующем шаге.',
+                status: 'Готово ✓'
+            });
+        } else {
+            this.setBannerState('warehouseBanner', {
+                state: 'active',
+                title: `Выберите склад для «${this.filters.marketplace}»`,
+                description: 'Выберите точку приёма, которая вам подходит.',
+                status: 'Шаг 2 из 3'
+            });
+        }
+    }
+
+    updateSelectionSummary() {
+        const marketplaceLabel = document.getElementById('selectedMarketplace');
+        if (marketplaceLabel) {
+            marketplaceLabel.textContent = this.filters.marketplace || '—';
+        }
+
+        const marketplaceSummary = document.getElementById('summaryMarketplace');
+        if (marketplaceSummary) {
+            const hasMarketplace = Boolean(this.filters.marketplace);
+            marketplaceSummary.textContent = `Маркетплейс: ${this.filters.marketplace || '—'}`;
+            marketplaceSummary.dataset.filled = hasMarketplace ? 'true' : 'false';
+        }
+
+        const warehouseSummary = document.getElementById('summaryWarehouse');
+        if (warehouseSummary) {
+            const hasWarehouse = Boolean(this.filters.warehouse);
+            warehouseSummary.textContent = `Склад: ${this.filters.warehouse || '—'}`;
+            warehouseSummary.dataset.filled = hasWarehouse ? 'true' : 'false';
+        }
+    }
+
+    updateScheduleSubtitle(message) {
+        const subtitle = document.getElementById('scheduleStepSubtitle');
+        if (subtitle) {
+            subtitle.textContent = message;
+        }
+    }
+
     showStep(stepNumber) {
         this.currentStep = stepNumber;
-        
+
+        this.updateStepWizardProgress();
         // Обновляем индикаторы шагов
         this.updateStepIndicators();
         
@@ -103,13 +209,20 @@ class ScheduleManager {
             const indicator = document.querySelector(`.step-indicator[data-step="${i}"]`);
             if (indicator) {
                 indicator.classList.remove('active', 'completed');
-                
+
                 if (i < this.currentStep) {
                     indicator.classList.add('completed');
                 } else if (i === this.currentStep) {
                     indicator.classList.add('active');
                 }
             }
+        }
+    }
+
+    updateStepWizardProgress() {
+        const wizard = document.querySelector('.step-wizard');
+        if (wizard) {
+            wizard.dataset.progress = String(this.currentStep);
         }
     }
 
@@ -139,6 +252,9 @@ class ScheduleManager {
     }
 
     async loadMarketplaces() {
+        this.isLoadingMarketplaces = true;
+        this.renderMarketplaces();
+
         try {
             const marketplaces = await fetchMarketplaces({ baseUrl: '../filter_options.php' });
             this.marketplaceOptions = marketplaces.map(mp => ({
@@ -146,10 +262,12 @@ class ScheduleManager {
                 label: mp,
                 description: this.getMarketplaceDescription(mp)
             }));
-            this.renderMarketplaces();
         } catch (error) {
             console.error('Ошибка загрузки маркетплейсов:', error);
             this.showError('Не удалось загрузить список маркетплейсов');
+        } finally {
+            this.isLoadingMarketplaces = false;
+            this.renderMarketplaces();
         }
     }
 
@@ -166,7 +284,21 @@ class ScheduleManager {
         const container = document.getElementById('marketplaceGrid');
         if (!container) return;
 
+        container.classList.remove('is-empty');
+
+        if (this.isLoadingMarketplaces) {
+            container.classList.add('is-empty');
+            container.innerHTML = `
+                <div class="loading">
+                    <div class="spinner"></div>
+                    Загружаем список маркетплейсов...
+                </div>
+            `;
+            return;
+        }
+
         if (this.marketplaceOptions.length === 0) {
+            container.classList.add('is-empty');
             container.innerHTML = `
                 <div class="empty-state">
                     <i class="fas fa-store-slash"></i>
@@ -177,21 +309,26 @@ class ScheduleManager {
             return;
         }
 
-        container.innerHTML = this.marketplaceOptions.map(option => `
-            <div class="marketplace-card ${this.filters.marketplace === option.value ? 'selected' : ''}" 
-                 data-value="${option.value}">
-                <div class="marketplace-icon">
-                    <i class="fas ${this.getMarketplaceIcon(option.value)}"></i>
+        container.innerHTML = this.marketplaceOptions.map(option => {
+            const value = this.escapeHtml(option.value);
+            const label = this.escapeHtml(option.label);
+            const description = this.escapeHtml(option.description);
+            return `
+                <div class="marketplace-card ${this.filters.marketplace === option.value ? 'selected' : ''}"
+                     data-value="${value}">
+                    <div class="marketplace-icon">
+                        <i class="fas ${this.getMarketplaceIcon(option.value)}"></i>
+                    </div>
+                    <div class="marketplace-info">
+                        <h3>${label}</h3>
+                        <p>${description}</p>
+                    </div>
+                    <div class="marketplace-check">
+                        <i class="fas fa-check"></i>
+                    </div>
                 </div>
-                <div class="marketplace-info">
-                    <h3>${option.label}</h3>
-                    <p>${option.description}</p>
-                </div>
-                <div class="marketplace-check">
-                    <i class="fas fa-check"></i>
-                </div>
-            </div>
-        `).join('');
+            `;
+        }).join('');
 
         // Добавляем обработчики кликов
         container.querySelectorAll('.marketplace-card').forEach(card => {
@@ -214,11 +351,24 @@ class ScheduleManager {
     selectMarketplace(marketplace) {
         this.filters.marketplace = marketplace;
         this.filters.warehouse = ''; // Сбрасываем выбор склада
-        
+        this.schedules = [];
+        this.filteredSchedules = [];
+        this.calendarData = {};
+        this.isLoadingSchedules = false;
+
+        this.updateMarketplaceBanner();
+        this.updateWarehouseBanner();
+        this.updateSelectionSummary();
+        this.renderScheduleGrid();
+        this.renderCalendar();
+
         // Обновляем визуальное состояние
         document.querySelectorAll('.marketplace-card').forEach(card => {
             card.classList.toggle('selected', card.dataset.value === marketplace);
         });
+
+        this.warehouseOptions = [];
+        this.renderWarehouses();
 
         // Автоматически переходим к следующему шагу
         setTimeout(() => {
@@ -232,22 +382,26 @@ class ScheduleManager {
             return;
         }
 
+        this.isLoadingWarehouses = true;
+        this.renderWarehouses();
+
         try {
-            const warehouses = await fetchWarehouses({ 
+            const warehouses = await fetchWarehouses({
                 marketplace: this.filters.marketplace,
-                baseUrl: '../filter_options.php' 
+                baseUrl: '../filter_options.php'
             });
-            
+
             this.warehouseOptions = warehouses.map(wh => ({
                 value: wh,
                 label: wh,
                 count: this.getWarehouseScheduleCount(wh)
             }));
-            
-            this.renderWarehouses();
         } catch (error) {
             console.error('Ошибка загрузки складов:', error);
             this.showError('Не удалось загрузить список складов');
+        } finally {
+            this.isLoadingWarehouses = false;
+            this.renderWarehouses();
         }
     }
 
@@ -262,7 +416,33 @@ class ScheduleManager {
         const container = document.getElementById('warehouseGrid');
         if (!container) return;
 
+        container.classList.remove('is-empty');
+
+        if (!this.filters.marketplace) {
+            container.classList.add('is-empty');
+            container.innerHTML = `
+                <div class="empty-state">
+                    <i class="fas fa-store"></i>
+                    <h3>Сначала выберите маркетплейс</h3>
+                    <p>Мы покажем доступные склады после выбора площадки.</p>
+                </div>
+            `;
+            return;
+        }
+
+        if (this.isLoadingWarehouses) {
+            container.classList.add('is-empty');
+            container.innerHTML = `
+                <div class="loading">
+                    <div class="spinner"></div>
+                    Загружаем склады...
+                </div>
+            `;
+            return;
+        }
+
         if (this.warehouseOptions.length === 0) {
+            container.classList.add('is-empty');
             container.innerHTML = `
                 <div class="empty-state">
                     <i class="fas fa-warehouse"></i>
@@ -274,21 +454,26 @@ class ScheduleManager {
         }
 
         // Создаем сетку складов
-        container.innerHTML = this.warehouseOptions.map(option => `
-            <div class="warehouse-card ${this.filters.warehouse === option.value ? 'selected' : ''}" 
-                 data-value="${option.value}">
-                <div class="warehouse-icon">
-                    <i class="fas fa-warehouse"></i>
+        container.innerHTML = this.warehouseOptions.map(option => {
+            const value = this.escapeHtml(option.value);
+            const label = this.escapeHtml(option.label);
+            const count = Number(option.count) || 0;
+            return `
+                <div class="warehouse-card ${this.filters.warehouse === option.value ? 'selected' : ''}"
+                     data-value="${value}">
+                    <div class="warehouse-icon">
+                        <i class="fas fa-warehouse"></i>
+                    </div>
+                    <div class="warehouse-info">
+                        <h4>${label}</h4>
+                        <span class="warehouse-count">${count} отправлений</span>
+                    </div>
+                    <div class="warehouse-check">
+                        <i class="fas fa-check"></i>
+                    </div>
                 </div>
-                <div class="warehouse-info">
-                    <h4>${option.label}</h4>
-                    <span class="warehouse-count">${option.count} отправлений</span>
-                </div>
-                <div class="warehouse-check">
-                    <i class="fas fa-check"></i>
-                </div>
-            </div>
-        `).join('');
+            `;
+        }).join('');
 
         // Добавляем обработчики кликов
         container.querySelectorAll('.warehouse-card').forEach(card => {
@@ -301,11 +486,17 @@ class ScheduleManager {
 
     selectWarehouse(warehouse) {
         this.filters.warehouse = warehouse;
-        
+
+        this.updateWarehouseBanner();
+        this.updateSelectionSummary();
+
         // Обновляем визуальное состояние
         document.querySelectorAll('.warehouse-card').forEach(card => {
             card.classList.toggle('selected', card.dataset.value === warehouse);
         });
+
+        this.isLoadingSchedules = true;
+        this.renderScheduleGrid();
 
         // Автоматически переходим к календарю
         setTimeout(() => {
@@ -315,12 +506,27 @@ class ScheduleManager {
 
     async loadSchedules() {
         if (!this.filters.marketplace || !this.filters.warehouse) {
-            this.showStep(1);
+            this.applyFilters();
             return;
         }
 
+        const cacheKey = `${this.filters.marketplace}__${this.filters.warehouse}`;
+        if (this.schedulesCache.has(cacheKey)) {
+            this.schedules = this.schedulesCache.get(cacheKey);
+            this.applyFilters();
+            return;
+        }
+
+        this.isLoadingSchedules = true;
+        this.renderScheduleGrid();
+
         try {
-            const response = await fetch('../fetch_schedule.php', {
+            const params = new URLSearchParams({
+                marketplace: this.filters.marketplace,
+                warehouse: this.filters.warehouse
+            });
+
+            const response = await fetch(`../fetch_schedule.php?${params.toString()}`, {
                 credentials: 'include'
             });
 
@@ -329,16 +535,30 @@ class ScheduleManager {
             }
 
             const data = await response.json();
-            this.schedules = data;
-            this.applyFilters();
-            this.renderCalendar();
+            this.schedules = Array.isArray(data) ? data : [];
+            this.schedulesCache.set(cacheKey, this.schedules);
         } catch (error) {
             console.error('Ошибка загрузки расписания:', error);
             this.showError('Не удалось загрузить расписание');
+            this.schedules = [];
+        } finally {
+            this.isLoadingSchedules = false;
+            this.applyFilters();
         }
     }
 
     applyFilters() {
+        if (!this.filters.marketplace || !this.filters.warehouse) {
+            this.filteredSchedules = [];
+            this.calendarData = {};
+            this.updateSelectionSummary();
+            this.updateMarketplaceBanner();
+            this.updateWarehouseBanner();
+            this.renderScheduleGrid();
+            this.renderCalendar();
+            return;
+        }
+
         this.filteredSchedules = this.schedules.filter(schedule => {
             const matchMarketplace = schedule.marketplace === this.filters.marketplace;
             const matchWarehouse = schedule.warehouses === this.filters.warehouse;
@@ -354,6 +574,150 @@ class ScheduleManager {
             }
             this.calendarData[date].push(schedule);
         });
+
+        this.updateSelectionSummary();
+        this.renderScheduleGrid();
+        this.renderCalendar();
+    }
+
+    renderScheduleGrid() {
+        const container = document.getElementById('scheduleGrid');
+        if (!container) return;
+
+        container.classList.remove('is-empty');
+
+        if (!this.filters.marketplace || !this.filters.warehouse) {
+            this.updateScheduleSubtitle('Чтобы увидеть расписание, выберите маркетплейс и склад');
+            container.classList.add('is-empty');
+            container.innerHTML = this.renderEmptyState(
+                'fa-layer-group',
+                'Расписание недоступно',
+                'Выберите маркетплейс и склад, чтобы мы показали подходящие отправления.'
+            );
+            return;
+        }
+
+        if (this.isLoadingSchedules) {
+            this.updateScheduleSubtitle(`Загружаем расписание для склада «${this.filters.warehouse}»...`);
+            container.classList.add('is-empty');
+            container.innerHTML = `
+                <div class="loading">
+                    <div class="spinner"></div>
+                    Подгружаем отправления...
+                </div>
+            `;
+            return;
+        }
+
+        if (this.filteredSchedules.length === 0) {
+            this.updateScheduleSubtitle('На выбранный склад пока нет активных отправлений');
+            container.classList.add('is-empty');
+            container.innerHTML = this.renderEmptyState(
+                'fa-calendar-times',
+                'Нет доступных отправлений',
+                'Попробуйте выбрать другую дату или склад, либо загляните позже.'
+            );
+            return;
+        }
+
+        this.updateScheduleSubtitle(`Доступно отправлений: ${this.filteredSchedules.length}`);
+        container.innerHTML = this.filteredSchedules
+            .map(schedule => this.renderScheduleCard(schedule))
+            .join('');
+    }
+
+    renderScheduleCard(schedule) {
+        const marketplace = this.escapeHtml(schedule.marketplace || '—');
+        const marketplaceClass = this.getMarketplaceBadgeClass(schedule.marketplace);
+        const city = this.escapeHtml(schedule.city || '—');
+        const warehouse = this.escapeHtml(schedule.warehouses || '—');
+        const acceptDate = this.formatDate(schedule.accept_date);
+        const acceptTime = this.escapeHtml(schedule.accept_time || '—');
+        const deliveryDate = this.formatDate(schedule.delivery_date);
+        const driver = this.escapeHtml(schedule.driver_name || '—');
+        const carInfo = this.escapeHtml([schedule.car_brand, schedule.car_number].filter(Boolean).join(' ') || '—');
+        const statusText = this.escapeHtml(schedule.status || '—');
+        const statusClass = this.getStatusClass(schedule.status);
+        const hasId = schedule && Object.prototype.hasOwnProperty.call(schedule, 'id');
+        const scheduleIdValue = hasId ? schedule.id : '';
+        const scheduleId = hasId ? JSON.stringify(schedule.id) : 'null';
+
+        return `
+            <article class="schedule-card" data-id="${this.escapeHtml(String(scheduleIdValue))}">
+                <div class="schedule-header">
+                    <div class="schedule-route">
+                        <i class="fas fa-route"></i>
+                        ${city} → ${warehouse}
+                    </div>
+                    <span class="schedule-marketplace ${marketplaceClass}">${marketplace}</span>
+                </div>
+                <div class="schedule-dates">
+                    <div class="date-item">
+                        <span class="date-label">Дата приёмки</span>
+                        <span class="date-value">${acceptDate}</span>
+                    </div>
+                    <div class="date-item">
+                        <span class="date-label">Время приёмки</span>
+                        <span class="date-value">${acceptTime}</span>
+                    </div>
+                    <div class="date-item">
+                        <span class="date-label">Дата отправки</span>
+                        <span class="date-value">${deliveryDate}</span>
+                    </div>
+                </div>
+                <div class="schedule-meta">
+                    <div class="meta-item">
+                        <span class="meta-label">Водитель</span>
+                        <span class="meta-value">${driver}</span>
+                    </div>
+                    <div class="meta-item">
+                        <span class="meta-label">Автомобиль</span>
+                        <span class="meta-value">${carInfo}</span>
+                    </div>
+                </div>
+                <div class="schedule-status status-${statusClass}">
+                    <span class="status-dot"></span>
+                    ${statusText}
+                </div>
+                <div class="schedule-action">
+                    <button class="create-order-btn" onclick="window.ScheduleManager.createOrderForSchedule(${scheduleId})">
+                        <i class="fas fa-plus"></i>
+                        Создать заявку
+                    </button>
+                </div>
+            </article>
+        `;
+    }
+
+    getMarketplaceBadgeClass(marketplace) {
+        if (!marketplace) {
+            return '';
+        }
+
+        const normalized = marketplace.toLowerCase();
+        if (normalized.includes('wildberries')) {
+            return 'marketplace-wb';
+        }
+        if (normalized.includes('ozon')) {
+            return 'marketplace-ozon';
+        }
+        if (normalized.includes('yandex')) {
+            return 'marketplace-yandex';
+        }
+        return '';
+    }
+
+    renderEmptyState(icon, title, description) {
+        const safeIcon = this.escapeHtml(icon);
+        const safeTitle = this.escapeHtml(title);
+        const safeDescription = this.escapeHtml(description);
+        return `
+            <div class="empty-state">
+                <i class="fas ${safeIcon}"></i>
+                <h3>${safeTitle}</h3>
+                <p>${safeDescription}</p>
+            </div>
+        `;
     }
 
     renderCalendar() {
@@ -374,6 +738,17 @@ class ScheduleManager {
 
         // Очищаем календарь
         calendarGrid.innerHTML = '';
+        calendarGrid.classList.remove('calendar-grid--empty');
+
+        if (!this.filters.marketplace || !this.filters.warehouse) {
+            calendarGrid.classList.add('calendar-grid--empty');
+            calendarGrid.innerHTML = this.renderEmptyState(
+                'fa-calendar-alt',
+                'Календарь недоступен',
+                'Выберите маркетплейс и склад, чтобы увидеть доступные даты.'
+            );
+            return;
+        }
 
         // Заголовки дней недели
         const dayHeaders = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'];
@@ -456,7 +831,7 @@ class ScheduleManager {
     openScheduleModal(date, schedules) {
         const modal = document.getElementById('scheduleDetailsModal');
         const content = document.getElementById('scheduleDetailsContent');
-        
+
         if (!content) return;
 
         const formattedDate = new Date(date).toLocaleDateString('ru-RU', {
@@ -522,6 +897,19 @@ class ScheduleManager {
         window.app.openModal(modal);
     }
 
+    escapeHtml(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
     getStatusClass(status) {
         const statusMap = {
             'Приём заявок': 'open',
@@ -542,7 +930,7 @@ class ScheduleManager {
     }
 
     createOrderForSchedule(scheduleId) {
-        const schedule = this.schedules.find(s => s.id === scheduleId);
+        const schedule = this.schedules.find(s => String(s.id) === String(scheduleId));
         if (!schedule) return;
 
         // Закрываем модальное окно деталей
@@ -581,6 +969,21 @@ class ScheduleManager {
             marketplace: '',
             warehouse: ''
         };
+        this.schedules = [];
+        this.filteredSchedules = [];
+        this.calendarData = {};
+        this.isLoadingSchedules = false;
+
+        this.updateMarketplaceBanner();
+        this.updateWarehouseBanner();
+        this.updateSelectionSummary();
+
+        this.renderMarketplaces();
+        this.warehouseOptions = [];
+        this.renderWarehouses();
+        this.renderScheduleGrid();
+        this.renderCalendar();
+
         this.showStep(1);
     }
 

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -448,6 +448,120 @@ body {
     font-size: 1.1rem;
 }
 
+.selection-grid {
+    display: grid;
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+.selection-banner {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    padding: 16px 24px;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
+    box-shadow: var(--shadow-sm);
+    margin-bottom: 24px;
+    transition: var(--transition);
+}
+
+.selection-banner__icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 16px;
+    background: var(--bg-tertiary);
+    color: var(--primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    flex-shrink: 0;
+    transition: var(--transition);
+}
+
+.selection-banner__content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.selection-banner__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.selection-banner__description {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+.selection-banner__status {
+    margin-left: auto;
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+}
+
+.selection-banner[data-state="active"] {
+    border-color: rgba(40, 199, 111, 0.4);
+    background: rgba(40, 199, 111, 0.08);
+}
+
+.selection-banner[data-state="active"] .selection-banner__icon {
+    background: rgba(40, 199, 111, 0.15);
+    color: var(--primary);
+}
+
+.selection-banner[data-state="completed"] {
+    border-color: rgba(16, 185, 129, 0.45);
+    background: rgba(16, 185, 129, 0.12);
+    box-shadow: 0 8px 24px rgba(16, 185, 129, 0.15);
+}
+
+.selection-banner[data-state="completed"] .selection-banner__icon {
+    background: var(--success);
+    color: white;
+}
+
+.selection-banner[data-state="completed"] .selection-banner__status {
+    color: var(--success);
+}
+
+.selection-banner[data-state="locked"] {
+    border-style: dashed;
+    border-color: var(--border);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    opacity: 0.75;
+}
+
+.selection-banner[data-state="locked"] .selection-banner__icon {
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+}
+
+.selection-banner[data-state="locked"] .selection-banner__status {
+    color: var(--text-light);
+}
+
+@media (max-width: 768px) {
+    .selection-banner {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .selection-banner__status {
+        margin-left: 0;
+    }
+}
+
 /* Marketplace Grid */
 .marketplace-grid {
     display: grid;
@@ -810,6 +924,18 @@ body {
 .step-nav-btn.secondary:hover {
     background: var(--border);
     color: var(--text-primary);
+}
+
+.step-nav-btn.ghost {
+    background: transparent;
+    border: 1px dashed var(--border);
+    color: var(--text-secondary);
+}
+
+.step-nav-btn.ghost:hover {
+    color: var(--primary);
+    border-color: var(--primary);
+    background: rgba(40, 199, 111, 0.08);
 }
 
 /* Schedule Day Details Modal */
@@ -1364,6 +1490,7 @@ body {
     font-size: 0.8rem;
     font-weight: 600;
     color: var(--text-secondary);
+}
 .warehouse-card.selected .warehouse-count {
     background: rgba(16, 185, 129, 0.2);
     color: var(--success);
@@ -1432,13 +1559,17 @@ body {
 .marketplace-grid,
 .warehouse-grid {
     min-height: 200px;
+}
+
+.marketplace-grid.is-empty,
+.warehouse-grid.is-empty {
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-.marketplace-grid:not(:empty),
-.warehouse-grid:not(:empty) {
+.marketplace-grid:not(.is-empty),
+.warehouse-grid:not(.is-empty) {
     display: grid;
 }
 
@@ -1459,6 +1590,12 @@ body {
     background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
     color: #1d4ed8;
     border: 1px solid rgba(29, 78, 216, 0.2);
+}
+
+.status-unknown {
+    background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+    color: #4b5563;
+    border: 1px solid rgba(75, 85, 99, 0.2);
 }
 
 .status-completed {
@@ -1488,12 +1625,24 @@ body {
     .calendar-grid {
         font-size: 0.8rem;
     }
-    
+
     .calendar-cell {
         min-height: 50px;
         padding: 2px;
     }
-    
+
+    .schedule-meta {
+        grid-template-columns: 1fr;
+    }
+
+    .calendar-panel {
+        padding: 16px;
+    }
+
+    .calendar-grid.calendar-grid--empty {
+        padding: 32px 16px;
+    }
+
     .schedule-indicator {
         flex-direction: column;
         gap: 2px;
@@ -1550,6 +1699,188 @@ body {
     flex-direction: column;
     gap: 8px;
     margin-bottom: 16px;
+}
+
+.schedule-step-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    gap: 24px;
+    align-items: flex-start;
+}
+
+.schedule-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 20px;
+}
+
+.schedule-grid.is-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.schedule-grid.is-empty .empty-state {
+    max-width: 420px;
+}
+
+.schedule-grid.is-empty .loading {
+    flex-direction: column;
+}
+
+.schedule-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    background: white;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow);
+    padding: 24px;
+    transition: var(--transition);
+    overflow: hidden;
+}
+
+.schedule-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(40, 199, 111, 0.08), transparent 60%);
+    opacity: 0;
+    transition: var(--transition);
+    pointer-events: none;
+}
+
+.schedule-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: rgba(40, 199, 111, 0.35);
+}
+
+.schedule-card:hover::before {
+    opacity: 1;
+}
+
+.schedule-meta {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.meta-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+}
+
+.meta-value {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.status-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.step-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 24px;
+}
+
+.summary-pill {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-weight: 600;
+    border: 1px solid transparent;
+    transition: var(--transition);
+    font-size: 0.95rem;
+}
+
+.summary-pill::before {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--text-light);
+}
+
+.summary-pill[data-filled="true"] {
+    background: rgba(40, 199, 111, 0.12);
+    color: var(--text-primary);
+    border-color: rgba(40, 199, 111, 0.35);
+}
+
+.summary-pill[data-filled="true"]::before {
+    background: var(--primary);
+}
+
+.calendar-panel {
+    background: white;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.calendar-panel .calendar-controls {
+    justify-content: space-between;
+    margin-bottom: 0;
+}
+
+.calendar-panel #currentMonth {
+    min-width: 0;
+}
+
+.calendar-panel .calendar-grid {
+    box-shadow: none;
+    border: 1px solid var(--border-light);
+}
+
+.calendar-grid.calendar-grid--empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 24px;
+    background: var(--bg-tertiary);
+    border: 1px dashed rgba(40, 199, 111, 0.3);
+    border-radius: var(--radius-lg);
+    box-shadow: none;
+    overflow: visible;
+}
+
+.calendar-grid.calendar-grid--empty .empty-state {
+    padding: 0;
+}
+
+.calendar-grid.calendar-grid--empty .empty-state i {
+    color: var(--primary);
 }
 
 .date-item {
@@ -2363,6 +2694,14 @@ body {
 
     .schedule-grid {
         grid-template-columns: 1fr;
+    }
+
+    .schedule-step-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .calendar-panel {
+        padding: 20px;
     }
 
     .orders-controls {


### PR DESCRIPTION
## Summary
- переработал клиентский раздел расписания с пошаговым мастером выбора маркетплейса, склада и календарного просмотра
- доработал ScheduleManager: загрузка по шагам, кэширование, карточки расписания и заглушки до выбора фильтров
- добавил стили для баннеров подсказок, плиток расписания, сводки выбора и пустых состояний

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb06b9fed0833398472976ce3c86c3