### PR TITLE
Добавить пошаговую анимацию выбора маркетплейса и склада

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -83,18 +83,59 @@ if (empty($_SESSION['user_id'])) {
 
             <div class="schedule-panel">
                 <div class="schedule-filters">
-                    <div class="schedule-filter">
-                        <label for="marketplaceFilter">Маркетплейс</label>
-                        <select id="marketplaceFilter" class="filter-select">
-                            <option value="">Загрузка...</option>
-                        </select>
+                    <div class="schedule-steps" id="scheduleSteps">
+                        <div class="schedule-step is-active" data-step="marketplace">
+                            <div class="step-header">
+                                <div class="step-title">
+                                    <span class="step-index">1</span>
+                                    <div class="step-text">
+                                        <h3>Выберите маркетплейс</h3>
+                                        <p>Укажите площадку, для которой хотите оформить отправление</p>
+                                    </div>
+                                </div>
+                                <button type="button" class="step-change-btn" id="changeMarketplaceBtn">Изменить</button>
+                            </div>
+                            <div class="step-body">
+                                <div class="schedule-filter">
+                                    <label for="marketplaceFilter">Маркетплейс</label>
+                                    <select id="marketplaceFilter" class="filter-select">
+                                        <option value="">Загрузка...</option>
+                                    </select>
+                                </div>
+                                <div class="step-actions">
+                                    <button type="button" class="step-next-btn" id="confirmMarketplace" disabled>Далее</button>
+                                </div>
+                            </div>
+                            <div class="step-summary" id="marketplaceSummary"></div>
+                        </div>
+
+                        <div class="schedule-step" data-step="warehouse">
+                            <div class="step-header">
+                                <div class="step-title">
+                                    <span class="step-index">2</span>
+                                    <div class="step-text">
+                                        <h3>Выберите склад</h3>
+                                        <p>Доступные склады покажутся после подтверждения маркетплейса</p>
+                                    </div>
+                                </div>
+                                <button type="button" class="step-change-btn" id="changeWarehouseBtn">Изменить</button>
+                            </div>
+                            <div class="step-body">
+                                <div class="schedule-filter">
+                                    <label for="warehouseFilter">Склад</label>
+                                    <select id="warehouseFilter" class="filter-select" disabled>
+                                        <option value="">Сначала выберите маркетплейс</option>
+                                    </select>
+                                </div>
+                                <div class="step-actions">
+                                    <button type="button" class="step-prev-btn" id="backToMarketplaceBtn">Назад</button>
+                                    <button type="button" class="step-next-btn" id="confirmWarehouse" disabled>Показать расписание</button>
+                                </div>
+                            </div>
+                            <div class="step-summary" id="warehouseSummary"></div>
+                        </div>
                     </div>
-                    <div class="schedule-filter">
-                        <label for="warehouseFilter">Склад</label>
-                        <select id="warehouseFilter" class="filter-select" disabled>
-                            <option value="">Сначала выберите маркетплейс</option>
-                        </select>
-                    </div>
+
                     <button class="reset-filters-btn" id="resetScheduleFilters">
                         <i class="fas fa-rotate-right"></i>
                         Сбросить фильтры

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -320,14 +320,14 @@ body {
 
 .schedule-filters {
     display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    align-items: flex-end;
+    flex-direction: column;
+    gap: 20px;
+    align-items: stretch;
     background: white;
     border: 1px solid var(--border);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow);
-    padding: 16px 20px;
+    padding: 20px 24px;
 }
 
 .schedule-filter {
@@ -381,12 +381,178 @@ body {
     cursor: pointer;
     transition: var(--transition);
     height: fit-content;
+    align-self: flex-end;
 }
 
 .reset-filters-btn:hover {
     border-color: var(--primary);
     color: var(--primary);
     background: rgba(40, 199, 111, 0.08);
+}
+
+.schedule-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.schedule-step {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+    padding: 16px 20px;
+    transition: var(--transition);
+    overflow: hidden;
+}
+
+.schedule-step.is-active {
+    border-color: rgba(40, 199, 111, 0.4);
+    box-shadow: var(--shadow-md);
+    animation: stepReveal 0.35s ease;
+}
+
+.schedule-step.is-complete {
+    border-color: rgba(37, 99, 235, 0.25);
+}
+
+.step-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.step-title {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.step-index {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--bg-tertiary);
+    color: var(--primary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.95rem;
+    transition: var(--transition);
+}
+
+.schedule-step.is-active .step-index {
+    background: var(--primary);
+    color: white;
+    box-shadow: 0 10px 24px -16px rgba(40, 199, 111, 0.9);
+}
+
+.step-text h3 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.step-text p {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
+
+.step-change-btn {
+    display: none;
+    border: none;
+    background: transparent;
+    color: var(--secondary);
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: var(--transition);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+}
+
+.step-change-btn:hover {
+    color: var(--primary);
+}
+
+.schedule-step.is-complete .step-change-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.step-body {
+    display: none;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 16px;
+    animation: stepBodyFade 0.35s ease;
+}
+
+.schedule-step.is-active .step-body {
+    display: flex;
+}
+
+.step-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.step-next-btn,
+.step-prev-btn {
+    padding: 10px 18px;
+    border-radius: var(--radius);
+    font-weight: 600;
+    cursor: pointer;
+    transition: var(--transition);
+    border: none;
+}
+
+.step-next-btn {
+    background: var(--primary);
+    color: white;
+    box-shadow: 0 14px 30px -18px rgba(40, 199, 111, 0.8);
+}
+
+.step-next-btn:hover:not(:disabled) {
+    background: var(--primary-dark);
+}
+
+.step-next-btn:disabled {
+    background: var(--bg-tertiary);
+    color: var(--text-light);
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.step-prev-btn {
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+}
+
+.step-prev-btn:hover {
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--secondary);
+}
+
+.step-summary {
+    margin-top: 12px;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    display: none;
+    opacity: 0;
+    transform: translateY(-6px);
+    transition: var(--transition);
+}
+
+.schedule-step.is-complete .step-summary {
+    display: block;
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .schedule-results {
@@ -405,6 +571,28 @@ body {
     from {
         opacity: 0;
         transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes stepReveal {
+    from {
+        opacity: 0;
+        transform: translateY(18px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes stepBodyFade {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
     }
     to {
         opacity: 1;
@@ -1337,6 +1525,35 @@ body {
     .main-content {
         margin-top: 0;
         padding: 20px 16px 80px;
+    }
+
+    .schedule-filters {
+        padding: 16px;
+    }
+
+    .schedule-step {
+        padding: 14px 16px;
+    }
+
+    .step-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+
+    .step-actions {
+        flex-direction: column;
+    }
+
+    .step-next-btn,
+    .step-prev-btn {
+        width: 100%;
+        text-align: center;
+    }
+
+    .reset-filters-btn {
+        align-self: stretch;
+        justify-content: center;
     }
 
     .filters {


### PR DESCRIPTION
## Summary
- Добавлен двухшаговый блок выбора маркетплейса и склада с кнопками подтверждения и ссылками для изменения выбора.
- Обновлена логика ScheduleManager для управления активным шагом, отложенного подтверждения и отображения кратких итогов выбора.
- Расширены стили: добавлены анимации шагов, оформление кнопок, сводок и мобильные адаптации для нового сценария.

## Testing
- `npm run build --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68cb3015dae483339f629aecd5c00079