### PR TITLE
Добавить карточки выбора маркетплейса и склада

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -83,18 +83,59 @@ if (empty($_SESSION['user_id'])) {
 
             <div class="schedule-panel">
                 <div class="schedule-filters">
-                    <div class="schedule-filter">
-                        <label for="marketplaceFilter">Маркетплейс</label>
-                        <select id="marketplaceFilter" class="filter-select">
-                            <option value="">Загрузка...</option>
-                        </select>
+                    <div class="schedule-steps" id="scheduleSteps">
+                        <div class="schedule-step is-active" data-step="marketplace">
+                            <div class="step-header">
+                                <div class="step-title">
+                                    <span class="step-index">1</span>
+                                    <div class="step-text">
+                                        <h3>Выберите маркетплейс</h3>
+                                        <p>Укажите площадку, для которой хотите оформить отправление</p>
+                                    </div>
+                                </div>
+                                <button type="button" class="step-change-btn" id="changeMarketplaceBtn">Изменить</button>
+                            </div>
+                            <div class="step-body">
+                                <div class="schedule-filter">
+                                    <span class="filter-label">Маркетплейс</span>
+                                    <div class="option-grid marketplace-grid" id="marketplaceOptions" role="group" aria-label="Выбор маркетплейса">
+                                        <div class="option-placeholder">Загрузка маркетплейсов...</div>
+                                    </div>
+                                </div>
+                                <div class="step-actions">
+                                    <button type="button" class="step-next-btn" id="confirmMarketplace" disabled>Далее</button>
+                                </div>
+                            </div>
+                            <div class="step-summary" id="marketplaceSummary"></div>
+                        </div>
+
+                        <div class="schedule-step" data-step="warehouse">
+                            <div class="step-header">
+                                <div class="step-title">
+                                    <span class="step-index">2</span>
+                                    <div class="step-text">
+                                        <h3>Выберите склад</h3>
+                                        <p>Доступные склады покажутся после подтверждения маркетплейса</p>
+                                    </div>
+                                </div>
+                                <button type="button" class="step-change-btn" id="changeWarehouseBtn">Изменить</button>
+                            </div>
+                            <div class="step-body">
+                                <div class="schedule-filter">
+                                    <span class="filter-label">Склад</span>
+                                    <div class="option-grid warehouse-grid is-disabled" id="warehouseOptions" role="group" aria-label="Выбор склада">
+                                        <div class="option-placeholder">Сначала выберите маркетплейс</div>
+                                    </div>
+                                </div>
+                                <div class="step-actions">
+                                    <button type="button" class="step-prev-btn" id="backToMarketplaceBtn">Назад</button>
+                                    <button type="button" class="step-next-btn" id="confirmWarehouse" disabled>Показать расписание</button>
+                                </div>
+                            </div>
+                            <div class="step-summary" id="warehouseSummary"></div>
+                        </div>
                     </div>
-                    <div class="schedule-filter">
-                        <label for="warehouseFilter">Склад</label>
-                        <select id="warehouseFilter" class="filter-select" disabled>
-                            <option value="">Сначала выберите маркетплейс</option>
-                        </select>
-                    </div>
+
                     <button class="reset-filters-btn" id="resetScheduleFilters">
                         <i class="fas fa-rotate-right"></i>
                         Сбросить фильтры

--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -16,34 +16,74 @@ class ScheduleManager {
         this.isLoadingSchedules = false;
         this.schedulesCache = new Map();
         this.elements = {
-            marketplaceSelect: document.getElementById('marketplaceFilter'),
-            warehouseSelect: document.getElementById('warehouseFilter'),
+            marketplaceContainer: document.getElementById('marketplaceOptions'),
+            warehouseContainer: document.getElementById('warehouseOptions'),
             resetButton: document.getElementById('resetScheduleFilters'),
             subtitle: document.getElementById('scheduleSubtitle')
         };
+        this.stepElements = {
+            marketplaceStep: document.querySelector('[data-step="marketplace"]'),
+            warehouseStep: document.querySelector('[data-step="warehouse"]'),
+            marketplaceSummary: document.getElementById('marketplaceSummary'),
+            warehouseSummary: document.getElementById('warehouseSummary'),
+            marketplaceConfirmBtn: document.getElementById('confirmMarketplace'),
+            warehouseConfirmBtn: document.getElementById('confirmWarehouse'),
+            backToMarketplaceBtn: document.getElementById('backToMarketplaceBtn'),
+            changeMarketplaceBtn: document.getElementById('changeMarketplaceBtn'),
+            changeWarehouseBtn: document.getElementById('changeWarehouseBtn')
+        };
+        this.pendingSelections = {
+            marketplace: '',
+            warehouse: ''
+        };
+        this.currentStep = 'marketplace';
 
         this.init();
     }
 
     init() {
         this.setupEventListeners();
+        this.applyStepState('marketplace', { active: true, complete: false });
+        this.applyStepState('warehouse', { active: false, complete: false });
+        this.updateMarketplaceConfirmState();
+        this.updateWarehouseConfirmState();
         this.renderScheduleGrid();
         this.renderWarehouses();
         this.loadMarketplaces();
     }
 
     setupEventListeners() {
-        const { marketplaceSelect, warehouseSelect, resetButton } = this.elements;
+        const { marketplaceContainer, warehouseContainer, resetButton } = this.elements;
 
-        if (marketplaceSelect) {
-            marketplaceSelect.addEventListener('change', (event) => {
-                this.selectMarketplace(event.target.value);
+        if (marketplaceContainer) {
+            marketplaceContainer.addEventListener('click', (event) => {
+                const target = event.target instanceof HTMLElement ? event.target.closest('.option-card') : null;
+                if (!target || target.classList.contains('is-disabled')) {
+                    return;
+                }
+
+                const value = target.getAttribute('data-value') || '';
+                if (!value) {
+                    return;
+                }
+
+                this.handleMarketplaceChange(value);
             });
         }
 
-        if (warehouseSelect) {
-            warehouseSelect.addEventListener('change', (event) => {
-                this.selectWarehouse(event.target.value);
+        if (warehouseContainer) {
+            warehouseContainer.addEventListener('click', (event) => {
+                const target = event.target instanceof HTMLElement ? event.target.closest('.option-card') : null;
+                if (!target || target.classList.contains('is-disabled')) {
+                    return;
+                }
+
+                const value = target.getAttribute('data-value') || '';
+                if (!value) {
+                    return;
+                }
+
+                this.handleWarehouseChange(value);
             });
         }
 
@@ -51,6 +91,210 @@ class ScheduleManager {
             resetButton.addEventListener('click', () => {
                 this.resetFilters();
             });
+        }
+
+        const {
+            marketplaceConfirmBtn,
+            warehouseConfirmBtn,
+            backToMarketplaceBtn,
+            changeMarketplaceBtn,
+            changeWarehouseBtn
+        } = this.stepElements;
+
+        if (marketplaceConfirmBtn) {
+            marketplaceConfirmBtn.addEventListener('click', () => {
+                this.confirmMarketplaceSelection();
+            });
+        }
+
+        if (warehouseConfirmBtn) {
+            warehouseConfirmBtn.addEventListener('click', () => {
+                this.confirmWarehouseSelection();
+            });
+        }
+
+        if (backToMarketplaceBtn) {
+            backToMarketplaceBtn.addEventListener('click', () => {
+                this.openMarketplaceStep();
+            });
+        }
+
+        if (changeMarketplaceBtn) {
+            changeMarketplaceBtn.addEventListener('click', () => {
+                this.openMarketplaceStep();
+            });
+        }
+
+        if (changeWarehouseBtn) {
+            changeWarehouseBtn.addEventListener('click', () => {
+                this.openWarehouseStep();
+            });
+        }
+    }
+
+    applyStepState(stepName, { active = false, complete = false } = {}) {
+        const stepKey = `${stepName}Step`;
+        const step = this.stepElements[stepKey];
+        if (!step) {
+            return;
+        }
+
+        if (active) {
+            step.classList.add('is-active');
+            this.triggerStepAnimation(step);
+        } else {
+            step.classList.remove('is-active');
+            step.classList.remove('is-animating');
+        }
+        step.classList.toggle('is-complete', complete);
+    }
+
+    handleMarketplaceChange(value) {
+        this.pendingSelections.marketplace = value;
+        this.updateMarketplaceConfirmState();
+        this.pendingSelections.warehouse = '';
+        this.updateWarehouseConfirmState();
+        this.applyStepState('warehouse', { active: false, complete: false });
+        this.clearWarehouseSummary();
+        this.renderMarketplaces();
+        this.renderWarehouses();
+
+        if (this.elements.marketplaceContainer) {
+            this.animateOptionSelection(this.elements.marketplaceContainer, value);
+        }
+
+        if (!value) {
+            this.clearMarketplaceSummary();
+        }
+    }
+
+    updateMarketplaceConfirmState() {
+        const button = this.stepElements.marketplaceConfirmBtn;
+        if (button) {
+            button.disabled = !this.pendingSelections.marketplace;
+        }
+    }
+
+    confirmMarketplaceSelection() {
+        if (!this.pendingSelections.marketplace) {
+            return;
+        }
+
+        this.selectMarketplace(this.pendingSelections.marketplace);
+        this.pendingSelections.marketplace = this.filters.marketplace;
+        this.showMarketplaceSummary();
+        this.renderMarketplaces();
+        this.applyStepState('marketplace', { active: false, complete: true });
+        this.applyStepState('warehouse', { active: true, complete: false });
+        this.currentStep = 'warehouse';
+        this.pendingSelections.warehouse = '';
+        this.updateWarehouseConfirmState();
+        this.clearWarehouseSummary();
+        this.renderWarehouses();
+    }
+
+    openMarketplaceStep() {
+        this.currentStep = 'marketplace';
+        this.applyStepState('marketplace', { active: true, complete: false });
+        const hasWarehouse = Boolean(this.filters.warehouse);
+        this.applyStepState('warehouse', { active: false, complete: hasWarehouse });
+        this.pendingSelections.marketplace = this.filters.marketplace || '';
+        this.updateMarketplaceConfirmState();
+        this.pendingSelections.warehouse = this.filters.warehouse || '';
+        this.updateWarehouseConfirmState();
+        this.renderMarketplaces();
+        this.renderWarehouses();
+    }
+
+    openWarehouseStep() {
+        if (!this.filters.marketplace) {
+            this.openMarketplaceStep();
+            return;
+        }
+
+        this.currentStep = 'warehouse';
+        this.applyStepState('marketplace', { active: false, complete: true });
+        this.applyStepState('warehouse', { active: true, complete: false });
+        this.pendingSelections.warehouse = this.filters.warehouse || '';
+        this.updateWarehouseConfirmState();
+
+        this.renderWarehouses();
+    }
+
+    handleWarehouseChange(value) {
+        this.pendingSelections.warehouse = value;
+        this.updateWarehouseConfirmState();
+        this.applyStepState('warehouse', { active: true, complete: false });
+        this.renderWarehouses();
+
+        if (this.elements.warehouseContainer) {
+            this.animateOptionSelection(this.elements.warehouseContainer, value);
+        }
+
+        if (!value) {
+            this.clearWarehouseSummary();
+        }
+    }
+
+    updateWarehouseConfirmState() {
+        const button = this.stepElements.warehouseConfirmBtn;
+        if (button) {
+            const hasMarketplace = Boolean(this.filters.marketplace || this.pendingSelections.marketplace);
+            button.disabled = !hasMarketplace || !this.pendingSelections.warehouse;
+        }
+    }
+
+    confirmWarehouseSelection() {
+        if (!this.pendingSelections.warehouse) {
+            return;
+        }
+
+        this.selectWarehouse(this.pendingSelections.warehouse);
+        this.pendingSelections.warehouse = this.filters.warehouse;
+        this.showWarehouseSummary();
+        this.renderWarehouses();
+        this.applyStepState('warehouse', { active: false, complete: true });
+    }
+
+    showMarketplaceSummary() {
+        const summary = this.stepElements.marketplaceSummary;
+        if (!summary) {
+            return;
+        }
+
+        if (!this.filters.marketplace) {
+            summary.textContent = '';
+            return;
+        }
+
+        summary.textContent = `Маркетплейс: ${this.filters.marketplace}`;
+    }
+
+    showWarehouseSummary() {
+        const summary = this.stepElements.warehouseSummary;
+        if (!summary) {
+            return;
+        }
+
+        if (!this.filters.warehouse) {
+            summary.textContent = '';
+            return;
+        }
+
+        summary.textContent = `Склад: ${this.filters.warehouse}`;
+    }
+
+    clearMarketplaceSummary() {
+        const summary = this.stepElements.marketplaceSummary;
+        if (summary) {
+            summary.textContent = '';
+        }
+    }
+
+    clearWarehouseSummary() {
+        const summary = this.stepElements.warehouseSummary;
+        if (summary) {
+            summary.textContent = '';
         }
     }
 
@@ -83,52 +327,44 @@ class ScheduleManager {
     }
 
     renderMarketplaces() {
-        const select = this.elements.marketplaceSelect;
-        if (!select) return;
+        const container = this.elements.marketplaceContainer;
+        if (!container) return;
 
-        select.innerHTML = '';
+        container.classList.toggle('is-loading', this.isLoadingMarketplaces);
 
         if (this.isLoadingMarketplaces) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'Загрузка маркетплейсов...';
-            option.disabled = true;
-            select.appendChild(option);
-            select.disabled = true;
+            container.innerHTML = this.renderOptionSkeleton(3);
             return;
         }
 
         if (this.marketplaceOptions.length === 0) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'Маркетплейсы недоступны';
-            option.disabled = true;
-            select.appendChild(option);
-            select.disabled = true;
+            container.innerHTML = '<div class="option-placeholder">Маркетплейсы недоступны</div>';
             return;
         }
 
-        const placeholderOption = document.createElement('option');
-        placeholderOption.value = '';
-        placeholderOption.textContent = 'Выберите маркетплейс';
-        select.appendChild(placeholderOption);
-
-        this.marketplaceOptions.forEach(optionData => {
-            const option = document.createElement('option');
-            option.value = optionData.value;
-            option.textContent = optionData.label;
-            if (optionData.description) {
-                option.title = optionData.description;
+        const selectedValue = this.pendingSelections.marketplace || this.filters.marketplace || '';
+        container.innerHTML = this.marketplaceOptions.map((optionData) => {
+            const isSelected = optionData.value === selectedValue;
+            const classes = ['option-card', 'marketplace-option', this.getMarketplaceAccentClass(optionData.value)];
+            if (isSelected) {
+                classes.push('is-selected');
             }
-            select.appendChild(option);
-        });
 
-        select.disabled = false;
-        const selected = this.filters.marketplace || '';
-        select.value = selected;
-        if (select.value !== selected) {
-            select.value = '';
-        }
+            const safeValue = this.escapeHtml(optionData.value);
+            const safeLabel = this.escapeHtml(optionData.label);
+            const initial = this.escapeHtml(this.getMarketplaceInitial(optionData.label));
+            const safeDescription = optionData.description ? this.escapeHtml(optionData.description) : '';
+
+            return `
+                <button type="button" class="${classes.filter(Boolean).join(' ')}" data-value="${safeValue}">
+                    <span class="option-icon" aria-hidden="true">${initial}</span>
+                    <span class="option-info">
+                        <span class="option-title">${safeLabel}</span>
+                        ${safeDescription ? `<span class="option-description">${safeDescription}</span>` : ''}
+                    </span>
+                </button>
+            `;
+        }).join('');
     }
 
     getMarketplaceDescription(marketplace) {
@@ -144,9 +380,11 @@ class ScheduleManager {
         this.filters.marketplace = marketplace;
         this.filters.warehouse = '';
 
-        if (this.elements.warehouseSelect) {
-            this.elements.warehouseSelect.value = '';
-        }
+        this.pendingSelections.marketplace = marketplace;
+        this.pendingSelections.warehouse = '';
+        this.updateMarketplaceConfirmState();
+        this.updateWarehouseConfirmState();
+        this.clearWarehouseSummary();
 
         this.warehouseOptions = [];
         this.schedules = [];
@@ -193,66 +431,175 @@ class ScheduleManager {
     }
 
     renderWarehouses() {
-        const select = this.elements.warehouseSelect;
-        if (!select) return;
+        const container = this.elements.warehouseContainer;
+        if (!container) return;
 
-        select.innerHTML = '';
+        const hasMarketplace = Boolean(this.filters.marketplace);
+        container.classList.toggle('is-disabled', !hasMarketplace);
 
-        if (!this.filters.marketplace) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'Сначала выберите маркетплейс';
-            select.appendChild(option);
-            select.disabled = true;
+        if (!hasMarketplace) {
+            container.innerHTML = '<div class="option-placeholder">Сначала выберите маркетплейс</div>';
             return;
         }
 
+        container.classList.toggle('is-loading', this.isLoadingWarehouses);
+
         if (this.isLoadingWarehouses) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'Загрузка складов...';
-            option.disabled = true;
-            select.appendChild(option);
-            select.disabled = true;
+            container.innerHTML = this.renderOptionSkeleton(4);
             return;
         }
 
         if (this.warehouseOptions.length === 0) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'Нет доступных складов';
-            option.disabled = true;
-            select.appendChild(option);
-            select.disabled = true;
+            container.innerHTML = '<div class="option-placeholder">Нет доступных складов</div>';
             return;
         }
 
-        const placeholderOption = document.createElement('option');
-        placeholderOption.value = '';
-        placeholderOption.textContent = 'Выберите склад';
-        select.appendChild(placeholderOption);
+        const selectedValue = this.pendingSelections.warehouse || this.filters.warehouse || '';
+        container.innerHTML = this.warehouseOptions.map((optionData) => {
+            const isSelected = optionData.value === selectedValue;
+            const classes = ['option-card', 'warehouse-option'];
+            if (isSelected) {
+                classes.push('is-selected');
+            }
 
-        this.warehouseOptions.forEach(optionData => {
-            const option = document.createElement('option');
-            option.value = optionData.value;
-            option.textContent = optionData.label;
-            select.appendChild(option);
-        });
+            const safeValue = this.escapeHtml(optionData.value);
+            const safeLabel = this.escapeHtml(optionData.label);
+            const shortNameRaw = this.getWarehouseShortName(optionData.label);
+            const shortName = this.escapeHtml(shortNameRaw);
+            const showFullName = shortNameRaw !== optionData.label;
 
-        select.disabled = false;
-        const selected = this.filters.warehouse || '';
-        select.value = selected;
-        if (select.value !== selected) {
-            select.value = '';
+            return `
+                <button type="button" class="${classes.join(' ')}" data-value="${safeValue}" title="${safeLabel}">
+                    <span class="option-title">${shortName}</span>
+                    ${showFullName ? `<span class="option-description">${safeLabel}</span>` : ''}
+                </button>
+            `;
+        }).join('');
+    }
+
+    renderOptionSkeleton(count = 3) {
+        return Array.from({ length: count })
+            .map(() => `
+                <div class="option-card is-skeleton">
+                    <span class="option-icon" aria-hidden="true"></span>
+                    <span class="option-info">
+                        <span class="option-title skeleton-line"></span>
+                        <span class="option-description skeleton-line"></span>
+                    </span>
+                </div>
+            `)
+            .join('');
+    }
+
+    animateOptionSelection(container, value) {
+        if (!container || !value) {
+            return;
         }
+
+        const selector = `.option-card[data-value="${this.escapeSelector(value)}"]`;
+        const button = container.querySelector(selector);
+        if (!button) {
+            return;
+        }
+
+        button.classList.remove('is-just-selected');
+        void button.offsetWidth;
+        button.classList.add('is-just-selected');
+        button.addEventListener('animationend', () => {
+            button.classList.remove('is-just-selected');
+        }, { once: true });
+    }
+
+    triggerStepAnimation(step) {
+        if (!step) {
+            return;
+        }
+
+        step.classList.remove('is-animating');
+        void step.offsetWidth;
+        step.classList.add('is-animating');
+        step.addEventListener('animationend', () => {
+            step.classList.remove('is-animating');
+        }, { once: true });
+    }
+
+    getMarketplaceInitial(label) {
+        if (!label) {
+            return '';
+        }
+
+        const trimmed = label.trim();
+        if (!trimmed) {
+            return '';
+        }
+
+        return trimmed.charAt(0).toUpperCase();
+    }
+
+    getMarketplaceAccentClass(marketplace) {
+        if (!marketplace) {
+            return 'accent-default';
+        }
+
+        const normalized = marketplace.toLowerCase();
+        if (normalized.includes('wildberries')) {
+            return 'accent-wb';
+        }
+        if (normalized.includes('ozon')) {
+            return 'accent-ozon';
+        }
+        if (normalized.includes('yandex') || normalized.includes('яндекс')) {
+            return 'accent-yandex';
+        }
+        if (normalized.includes('sber') || normalized.includes('сбер')) {
+            return 'accent-sber';
+        }
+        return 'accent-default';
+    }
+
+    getWarehouseShortName(name) {
+        if (!name) {
+            return '';
+        }
+
+        const trimmed = name.trim();
+        if (trimmed.length <= 28) {
+            return trimmed;
+        }
+
+        const parts = trimmed.split(',');
+        if (parts.length >= 2) {
+            const city = parts[0].trim();
+            const rest = parts.slice(1).join(',').trim();
+            const cityShort = city.length > 9 ? `${city.slice(0, 9)}…` : city;
+            const restShort = rest.length > 14 ? `${rest.slice(0, 14)}…` : rest;
+            return `${cityShort} ${restShort}`.trim();
+        }
+
+        return `${trimmed.slice(0, 27)}…`;
+    }
+
+    escapeSelector(value) {
+        if (!value) {
+            return '';
+        }
+
+        if (window.CSS && typeof window.CSS.escape === 'function') {
+            return window.CSS.escape(value);
+        }
+
+        return String(value).replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '\\$1');
     }
 
     selectWarehouse(warehouse) {
         this.filters.warehouse = warehouse;
+        this.pendingSelections.warehouse = warehouse;
+        this.updateWarehouseConfirmState();
 
         if (!warehouse) {
             this.filteredSchedules = [];
             this.renderScheduleGrid();
+            this.clearWarehouseSummary();
             return;
         }
 
@@ -560,14 +907,16 @@ class ScheduleManager {
         this.filteredSchedules = [];
         this.warehouseOptions = [];
         this.isLoadingSchedules = false;
+        this.pendingSelections.marketplace = '';
+        this.pendingSelections.warehouse = '';
+        this.currentStep = 'marketplace';
 
-        if (this.elements.marketplaceSelect) {
-            this.elements.marketplaceSelect.value = '';
-        }
-
-        if (this.elements.warehouseSelect) {
-            this.elements.warehouseSelect.value = '';
-        }
+        this.applyStepState('marketplace', { active: true, complete: false });
+        this.applyStepState('warehouse', { active: false, complete: false });
+        this.clearMarketplaceSummary();
+        this.clearWarehouseSummary();
+        this.updateMarketplaceConfirmState();
+        this.updateWarehouseConfirmState();
 
         this.renderMarketplaces();
         this.renderWarehouses();

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -320,14 +320,14 @@ body {
 
 .schedule-filters {
     display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    align-items: flex-end;
+    flex-direction: column;
+    gap: 20px;
+    align-items: stretch;
     background: white;
     border: 1px solid var(--border);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow);
-    padding: 16px 20px;
+    padding: 20px 24px;
 }
 
 .schedule-filter {
@@ -338,7 +338,8 @@ body {
     flex: 1 1 240px;
 }
 
-.schedule-filter label {
+.schedule-filter label,
+.schedule-filter .filter-label {
     font-weight: 600;
     font-size: 0.95rem;
     color: var(--text-secondary);
@@ -368,6 +369,171 @@ body {
     cursor: not-allowed;
 }
 
+.option-grid {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    width: 100%;
+}
+
+.option-grid.is-disabled {
+    pointer-events: none;
+    opacity: 0.55;
+    filter: grayscale(0.1);
+}
+
+.option-grid.is-loading {
+    opacity: 0.85;
+}
+
+.marketplace-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.warehouse-grid {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.option-placeholder {
+    padding: 16px;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-size: 0.92rem;
+    text-align: center;
+}
+
+.option-card {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 16px;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    width: 100%;
+    min-height: 72px;
+    text-align: left;
+    color: var(--text-primary);
+    font: inherit;
+    appearance: none;
+    -webkit-appearance: none;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+}
+
+.option-card:hover,
+.option-card:focus-visible {
+    border-color: rgba(40, 199, 111, 0.35);
+    box-shadow: var(--shadow-md), 0 0 0 3px rgba(40, 199, 111, 0.12);
+    transform: translateY(-2px);
+    outline: none;
+}
+
+.option-card .option-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    color: white;
+    background: var(--secondary);
+    font-size: 1.05rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.option-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-start;
+}
+
+.option-title {
+    font-weight: 600;
+    font-size: 0.98rem;
+    color: var(--text-primary);
+    line-height: 1.3;
+    word-break: break-word;
+}
+
+.option-description {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.3;
+    max-width: 100%;
+    word-break: break-word;
+}
+
+.option-card.is-selected {
+    border-color: rgba(40, 199, 111, 0.55);
+    box-shadow: 0 18px 32px -22px rgba(40, 199, 111, 0.65);
+    background: linear-gradient(135deg, rgba(40, 199, 111, 0.12) 0%, rgba(40, 199, 111, 0.05) 100%);
+}
+
+.option-card.is-selected .option-title {
+    color: var(--primary-dark);
+}
+
+.option-card.is-selected .option-icon {
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.35), 0 10px 20px -16px rgba(40, 199, 111, 0.9);
+}
+
+.option-card.is-just-selected {
+    animation: optionPulse 0.5s ease;
+}
+
+.option-card.is-skeleton {
+    pointer-events: none;
+    border-style: dashed;
+    background: var(--bg-secondary);
+    box-shadow: none;
+    cursor: default;
+}
+
+.option-card.is-skeleton .option-icon {
+    background: linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(148, 163, 184, 0.15));
+}
+
+.skeleton-line {
+    display: block;
+    width: 120px;
+    height: 10px;
+    border-radius: 20px;
+    background: linear-gradient(90deg, rgba(229, 231, 235, 0.6) 0%, rgba(243, 244, 246, 0.9) 50%, rgba(229, 231, 235, 0.6) 100%);
+    animation: skeletonGlow 1.4s ease-in-out infinite;
+}
+
+.skeleton-line + .skeleton-line {
+    width: 90px;
+}
+
+.accent-wb .option-icon {
+    background: linear-gradient(135deg, #ef5da8 0%, #f97316 100%);
+}
+
+.accent-ozon .option-icon {
+    background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+}
+
+.accent-yandex .option-icon {
+    background: linear-gradient(135deg, #facc15 0%, #f97316 100%);
+    color: #92400e;
+}
+
+.accent-sber .option-icon {
+    background: linear-gradient(135deg, #34d399 0%, #10b981 100%);
+}
+
+.accent-default .option-icon {
+    background: linear-gradient(135deg, #6366f1 0%, #2563eb 100%);
+}
+
 .reset-filters-btn {
     display: inline-flex;
     align-items: center;
@@ -381,12 +547,181 @@ body {
     cursor: pointer;
     transition: var(--transition);
     height: fit-content;
+    align-self: flex-end;
 }
 
 .reset-filters-btn:hover {
     border-color: var(--primary);
     color: var(--primary);
     background: rgba(40, 199, 111, 0.08);
+}
+
+.schedule-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.schedule-step {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+    padding: 16px 20px;
+    transition: var(--transition);
+    overflow: hidden;
+}
+
+.schedule-step.is-active {
+    border-color: rgba(40, 199, 111, 0.4);
+    box-shadow: var(--shadow-md);
+}
+
+.schedule-step.is-complete {
+    border-color: rgba(37, 99, 235, 0.25);
+}
+
+.schedule-step.is-animating {
+    animation: stepSlideIn 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.step-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.step-title {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.step-index {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--bg-tertiary);
+    color: var(--primary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.95rem;
+    transition: var(--transition);
+}
+
+.schedule-step.is-active .step-index {
+    background: var(--primary);
+    color: white;
+    box-shadow: 0 10px 24px -16px rgba(40, 199, 111, 0.9);
+}
+
+.step-text h3 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.step-text p {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
+
+.step-change-btn {
+    display: none;
+    border: none;
+    background: transparent;
+    color: var(--secondary);
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: var(--transition);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+}
+
+.step-change-btn:hover {
+    color: var(--primary);
+}
+
+.schedule-step.is-complete .step-change-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.step-body {
+    display: none;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 16px;
+    animation: stepBodyFade 0.35s ease;
+}
+
+.schedule-step.is-active .step-body {
+    display: flex;
+}
+
+.step-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.step-next-btn,
+.step-prev-btn {
+    padding: 10px 18px;
+    border-radius: var(--radius);
+    font-weight: 600;
+    cursor: pointer;
+    transition: var(--transition);
+    border: none;
+}
+
+.step-next-btn {
+    background: var(--primary);
+    color: white;
+    box-shadow: 0 14px 30px -18px rgba(40, 199, 111, 0.8);
+}
+
+.step-next-btn:hover:not(:disabled) {
+    background: var(--primary-dark);
+}
+
+.step-next-btn:disabled {
+    background: var(--bg-tertiary);
+    color: var(--text-light);
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.step-prev-btn {
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+}
+
+.step-prev-btn:hover {
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--secondary);
+}
+
+.step-summary {
+    margin-top: 12px;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    display: none;
+    opacity: 0;
+    transform: translateY(-6px);
+    transition: var(--transition);
+}
+
+.schedule-step.is-complete .step-summary {
+    display: block;
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .schedule-results {
@@ -405,6 +740,32 @@ body {
     from {
         opacity: 0;
         transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes stepSlideIn {
+    0% {
+        opacity: 0;
+        transform: translateY(20px) scale(0.98);
+    }
+    60% {
+        opacity: 1;
+        transform: translateY(-4px) scale(1.01);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes stepBodyFade {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
     }
     to {
         opacity: 1;
@@ -435,6 +796,30 @@ body {
     100% {
         transform: scale(1);
         box-shadow: 0 18px 32px -18px rgba(40, 199, 111, 0.7);
+    }
+}
+
+@keyframes optionPulse {
+    0% {
+        transform: translateY(0) scale(1);
+    }
+    50% {
+        transform: translateY(-3px) scale(1.03);
+    }
+    100% {
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes skeletonGlow {
+    0% {
+        opacity: 0.55;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0.55;
     }
 }
 
@@ -1339,6 +1724,43 @@ body {
         padding: 20px 16px 80px;
     }
 
+    .schedule-filters {
+        padding: 16px;
+    }
+
+    .schedule-step {
+        padding: 14px 16px;
+    }
+
+    .marketplace-grid {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .warehouse-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    }
+
+    .step-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+
+    .step-actions {
+        flex-direction: column;
+    }
+
+    .step-next-btn,
+    .step-prev-btn {
+        width: 100%;
+        text-align: center;
+    }
+
+    .reset-filters-btn {
+        align-self: stretch;
+        justify-content: center;
+    }
+
     .filters {
         grid-template-columns: 1fr;
         gap: 16px;
@@ -1433,6 +1855,21 @@ body {
 
     .filter-step-action {
         font-size: 0.9rem;
+    }
+
+    .marketplace-grid,
+    .warehouse-grid {
+        grid-template-columns: repeat(2, minmax(140px, 1fr));
+    }
+
+    .option-card {
+        padding: 12px 14px;
+    }
+
+    .option-card .option-icon {
+        width: 36px;
+        height: 36px;
+        font-size: 0.95rem;
     }
 
     .stats-grid {


### PR DESCRIPTION
## Summary
- Заменены выпадающие списки шагов расписания на карточки с выбором маркетплейса и склада, включая предзагрузку и анимацию выбора.
- Обновлён ScheduleManager: добавлены обработчики кликов, скелетоны загрузки, переработанные резюме выбора и плавные анимации переключения шагов.
- Расширены стили: оформлены сетки карточек, индикаторы маркетплейсов, мобильная адаптация и новые keyframes для шагов и кнопок.

## Testing
- `npm run build --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68cb3015dae483339f629aecd5c00079