### PR TITLE
Показывать статистику склада до подтверждения выбора

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -97,10 +97,17 @@ if (empty($_SESSION['user_id'])) {
                             </div>
                             <div class="step-body">
                                 <div class="schedule-filter">
-                                    <label for="marketplaceFilter">Маркетплейс</label>
-                                    <select id="marketplaceFilter" class="filter-select">
-                                        <option value="">Загрузка...</option>
-                                    </select>
+                                    <label id="marketplaceFilterLabel">Маркетплейс</label>
+                                    <div
+                                        id="marketplaceFilter"
+                                        class="marketplace-grid"
+                                        role="group"
+                                        aria-labelledby="marketplaceFilterLabel"
+                                    >
+                                        <div class="marketplace-placeholder marketplace-placeholder--loading">
+                                            <span>Загрузка маркетплейсов...</span>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="step-actions">
                                     <button type="button" class="step-next-btn" id="confirmMarketplace" disabled>Далее</button>
@@ -127,6 +134,13 @@ if (empty($_SESSION['user_id'])) {
                                         <option value="">Сначала выберите маркетплейс</option>
                                     </select>
                                 </div>
+                                <div
+                                    id="warehouseStats"
+                                    class="warehouse-stats"
+                                    aria-live="polite"
+                                    aria-atomic="true"
+                                    aria-hidden="true"
+                                ></div>
                                 <div class="step-actions">
                                     <button type="button" class="step-prev-btn" id="backToMarketplaceBtn">Назад</button>
                                     <button type="button" class="step-next-btn" id="confirmWarehouse" disabled>Показать расписание</button>

--- a/client/js/filterOptions.js
+++ b/client/js/filterOptions.js
@@ -73,8 +73,14 @@ export async function fetchWarehouses({ marketplace = '', city = '', baseUrl = '
         action = 'warehouses';
         params.marketplace = marketplace;
         params.city = city;
-    } else if (city) {
-        params.city = city;
+    } else {
+        if (marketplace) {
+            params.marketplace = marketplace;
+        }
+
+        if (city) {
+            params.city = city;
+        }
     }
 
     try {

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -363,6 +363,274 @@ body {
     background: white;
 }
 
+.warehouse-stats {
+    display: grid;
+    gap: 12px;
+    border-radius: var(--radius-lg);
+    border: 1px solid transparent;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+    margin-top: 0;
+    opacity: 0;
+    transform: translateY(8px);
+    pointer-events: none;
+    max-height: 0;
+    overflow: hidden;
+    transition:
+        opacity 0.3s ease,
+        transform 0.3s ease,
+        max-height 0.3s ease,
+        padding 0.3s ease,
+        margin-top 0.3s ease,
+        border-color 0.3s ease,
+        background 0.3s ease,
+        box-shadow 0.3s ease;
+}
+
+.warehouse-stats.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+    background: var(--bg-secondary);
+    border-color: rgba(40, 199, 111, 0.18);
+    box-shadow: var(--shadow-sm);
+    padding: 16px 18px;
+    margin-top: 6px;
+    max-height: 520px;
+}
+
+.warehouse-stats__header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.warehouse-stats__title {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--text-primary);
+}
+
+.warehouse-stats__grid {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.warehouse-stats__item {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 16px;
+    border-radius: var(--radius);
+    border: 1px solid rgba(17, 24, 39, 0.06);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, #ffffff 100%);
+    box-shadow: var(--shadow-sm);
+    min-height: 88px;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.warehouse-stats__item:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow);
+}
+
+.warehouse-stats__label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.warehouse-stats__value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--primary);
+    line-height: 1.1;
+}
+
+.warehouse-stats__description {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+.warehouse-stats__item--loading .warehouse-stats__value,
+.warehouse-stats__item--error .warehouse-stats__value {
+    color: var(--text-secondary);
+}
+
+.warehouse-stats__item--error {
+    border-color: rgba(239, 68, 68, 0.25);
+}
+
+.warehouse-stats__item--error .warehouse-stats__description {
+    color: var(--error);
+}
+
+.warehouse-stats__spinner {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 2px solid rgba(40, 199, 111, 0.25);
+    border-top-color: var(--primary);
+    animation: spin 0.9s linear infinite;
+}
+
+@media (max-width: 900px) {
+    .warehouse-stats.is-visible {
+        padding: 14px 16px;
+    }
+}
+
+@media (max-width: 640px) {
+    .warehouse-stats__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .warehouse-stats__item {
+        min-height: 88px;
+    }
+}
+
+.marketplace-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    width: 100%;
+    transition: opacity 0.3s ease;
+}
+
+.marketplace-grid.is-loading,
+.marketplace-grid.is-disabled {
+    pointer-events: none;
+    opacity: 0.7;
+}
+
+.marketplace-grid.is-loading {
+    cursor: progress;
+}
+
+.marketplace-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: flex-start;
+    justify-content: center;
+    width: 100%;
+    padding: 16px 18px;
+    min-height: 92px;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.95rem;
+    text-align: left;
+    cursor: pointer;
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.2s ease, background-color 0.2s ease;
+    overflow: hidden;
+}
+
+.marketplace-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(40, 199, 111, 0.08), rgba(37, 99, 235, 0.06));
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
+}
+
+.marketplace-card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(40, 199, 111, 0.35);
+    box-shadow: var(--shadow-md);
+}
+
+.marketplace-card:hover::after {
+    opacity: 1;
+}
+
+.marketplace-card:focus-visible {
+    outline: 3px solid rgba(40, 199, 111, 0.35);
+    outline-offset: 2px;
+}
+
+.marketplace-card.is-active {
+    transform: translateY(-4px);
+    border-color: transparent;
+    background: linear-gradient(135deg, var(--primary), var(--primary-light));
+    color: #ffffff;
+    box-shadow: var(--shadow-md);
+}
+
+.marketplace-card.is-active::after {
+    opacity: 0.35;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+}
+
+.marketplace-card__title {
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+}
+
+.marketplace-card__description {
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    line-height: 1.35;
+}
+
+.marketplace-card.is-active .marketplace-card__description {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.marketplace-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 18px;
+    min-height: 92px;
+    border-radius: var(--radius-lg);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-weight: 500;
+    box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.marketplace-placeholder--loading::before {
+    content: '';
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+    border-radius: 50%;
+    border: 2px solid rgba(40, 199, 111, 0.35);
+    border-top-color: var(--primary);
+    animation: spin 0.75s linear infinite;
+}
+
+@media (max-width: 768px) {
+    .marketplace-card {
+        min-height: 84px;
+        padding: 14px 16px;
+    }
+}
+
+@media (max-width: 520px) {
+    .marketplace-grid {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+}
+
 .filter-select:disabled {
     opacity: 0.7;
     cursor: not-allowed;

--- a/filter_options.php
+++ b/filter_options.php
@@ -72,17 +72,27 @@ switch ($action) {
 
         // --- ВСЕ СКЛАДЫ (по всем городам/маркетплейсам или по конкретному городу) ---
         case 'all_warehouses':
-        $sql = "SELECT DISTINCT warehouses FROM schedules 
-                WHERE warehouses IS NOT NULL 
-                  AND warehouses != '' 
-                  AND status != 'Завершено' 
+        $sql = "SELECT DISTINCT warehouses FROM schedules
+                WHERE warehouses IS NOT NULL
+                  AND warehouses != ''
+                  AND status != 'Завершено'
                   AND accept_date >= CURDATE()";
         $params = [];
         $types  = "";
-        if (!empty($_GET['city'])) {
-            $sql       .= " AND city = ?";
-            $params[]   = $_GET['city'];
-            $types     .= "s";
+
+        $marketplace = isset($_GET['marketplace']) ? trim($_GET['marketplace']) : '';
+        $city = isset($_GET['city']) ? trim($_GET['city']) : '';
+
+        if ($marketplace !== '') {
+            $sql     .= " AND marketplace = ?";
+            $params[] = $marketplace;
+            $types   .= "s";
+        }
+
+        if ($city !== '') {
+            $sql     .= " AND city = ?";
+            $params[] = $city;
+            $types   .= "s";
         }
         $stmt = $conn->prepare($sql);
         if ($params) {

--- a/get_warehouse_stats.php
+++ b/get_warehouse_stats.php
@@ -1,0 +1,140 @@
+<?php
+require_once 'auth_helper.php';
+requireLogin();
+
+header('Content-Type: application/json; charset=utf-8');
+
+require_once 'db_connection.php';
+
+$marketplace = isset($_GET['marketplace']) ? trim((string) $_GET['marketplace']) : '';
+$warehouse   = isset($_GET['warehouse']) ? trim((string) $_GET['warehouse']) : '';
+
+if ($marketplace === '' || $warehouse === '') {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Параметры marketplace и warehouse обязательны'
+    ], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+/**
+ * Подсчёт количества заказов с учётом выбранного маркетплейса и склада.
+ */
+function normalizeMarketplaceKey(string $value): string
+{
+    $lower = mb_strtolower($value, 'UTF-8');
+    return str_replace([' ', '-', '_'], '', $lower);
+}
+
+function normalizeWarehouseValue(string $value): string
+{
+    return mb_strtolower(trim($value), 'UTF-8');
+}
+
+function countOrdersByMarketplace(mysqli $conn, string $marketplace, ?string $warehouse = null): int
+{
+    $sql = "SELECT COUNT(*) AS total FROM orders WHERE is_deleted = 0 AND status <> 'Удалён клиентом'";
+    $params = [];
+    $types  = '';
+
+    $normalizedMarketplace = normalizeMarketplaceKey($marketplace);
+    if ($normalizedMarketplace !== '') {
+        $marketplaceConditions = [];
+
+        $marketplaceConditions[] = "REPLACE(REPLACE(REPLACE(LOWER(schedule_marketplace), ' ', ''), '-', ''), '_', '') = ?";
+        $params[] = $normalizedMarketplace;
+        $types   .= 's';
+
+        if ($normalizedMarketplace === 'wildberries') {
+            $marketplaceConditions[] = 'marketplace_wildberries = 1';
+        } elseif ($normalizedMarketplace === 'ozon') {
+            $marketplaceConditions[] = 'marketplace_ozon = 1';
+        }
+
+        if (!empty($marketplaceConditions)) {
+            $sql .= ' AND (' . implode(' OR ', $marketplaceConditions) . ')';
+        }
+    }
+
+    if ($warehouse !== null && $warehouse !== '') {
+        $sql        .= ' AND LOWER(TRIM(schedule_warehouses)) = ?';
+        $params[]    = normalizeWarehouseValue($warehouse);
+        $types      .= 's';
+    }
+
+    $stmt = $conn->prepare($sql);
+    if (!empty($params)) {
+        $stmt->bind_param($types, ...$params);
+    }
+    $stmt->execute();
+    $stmt->bind_result($count);
+    $stmt->fetch();
+    $stmt->close();
+
+    return (int) $count;
+}
+
+function countSchedulesByWarehouse(mysqli $conn, string $marketplace, string $warehouse): array
+{
+    $sql = <<<SQL
+        SELECT
+            COUNT(*) AS schedules_total,
+            COUNT(DISTINCT NULLIF(TRIM(accept_date), '')) AS departures_unique
+        FROM schedules
+        WHERE status <> 'Завершено'
+          AND LOWER(TRIM(marketplace)) = ?
+          AND LOWER(TRIM(warehouses)) = ?
+    SQL;
+
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        throw new RuntimeException('Ошибка подготовки запроса статистики расписаний: ' . $conn->error);
+    }
+
+    $marketplaceParam = normalizeWarehouseValue($marketplace);
+    $warehouseParam   = normalizeWarehouseValue($warehouse);
+    $stmt->bind_param('ss', $marketplaceParam, $warehouseParam);
+    $stmt->execute();
+    $stmt->bind_result($total, $unique);
+    $stmt->fetch();
+    $stmt->close();
+
+    return [
+        'schedules_total'   => (int) $total,
+        'departures_unique' => (int) $unique,
+    ];
+}
+
+try {
+    $ordersTotal = countOrdersByMarketplace($conn, $marketplace);
+    $ordersForWarehouse = countOrdersByMarketplace($conn, $marketplace, $warehouse);
+    $schedulesStats = countSchedulesByWarehouse($conn, $marketplace, $warehouse);
+
+    $percentage = 0.0;
+    if ($ordersTotal > 0) {
+        $percentage = ($ordersForWarehouse / $ordersTotal) * 100;
+    }
+
+    echo json_encode([
+        'success' => true,
+        'marketplace' => $marketplace,
+        'warehouse' => $warehouse,
+        'orders_total' => $ordersTotal,
+        'orders_for_warehouse' => $ordersForWarehouse,
+        'orders_percentage' => round($percentage, 2),
+        'departures_unique' => $schedulesStats['departures_unique'],
+        'departures_total' => $schedulesStats['schedules_total'],
+    ], JSON_UNESCAPED_UNICODE);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Не удалось получить статистику склада',
+        'error' => $e->getMessage(),
+    ], JSON_UNESCAPED_UNICODE);
+} finally {
+    if (isset($conn) && $conn instanceof mysqli) {
+        $conn->close();
+    }
+}


### PR DESCRIPTION
## Summary
- показываем статистику склада сразу после выбора склада и скрываем блок после показа расписания, используя кеш и упрощённый текст
- дополнили серверный эндпоинт расчётом уникальных дат отправлений и отдаем его вместе с долей заказов
- обновили стили блока статистики, чтобы он располагался ближе к выпадающему списку и выглядел лаконичнее

## Testing
- npm run build --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68cb59b0466c83338fc9a2cfca8a978a