### PR TITLE
Expose schedule action button in schedule cards

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -1625,6 +1625,18 @@ class ScheduleManager {
                             </div>
                         </div>
                     </div>
+
+                    <div class="schedule-action">
+                        <button
+                            type="button"
+                            class="create-order-btn"
+                            data-group-key="${safeGroupIdentifier}"
+                            data-schedule-id="${safeScheduleId}"
+                        >
+                            <i class="fas fa-plus"></i>
+                            Создать заявку
+                        </button>
+                    </div>
                 </div>
 
                 <div class="schedule-card-extra" id="${extraSectionId}" aria-hidden="true">
@@ -1650,18 +1662,6 @@ class ScheduleManager {
                             <span class="meta-label">Города</span>
                             <span class="meta-value">${citiesSummary}</span>
                         </div>
-                    </div>
-
-                    <div class="schedule-action">
-                        <button
-                            type="button"
-                            class="create-order-btn"
-                            data-group-key="${safeGroupIdentifier}"
-                            data-schedule-id="${safeScheduleId}"
-                        >
-                            <i class="fas fa-plus"></i>
-                            Создать заявку
-                        </button>
                     </div>
                 </div>
 

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -1166,9 +1166,9 @@ body {
 
 .schedule-card-main {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 16px;
 }
 
 .schedule-card-warehouse {
@@ -1473,8 +1473,14 @@ body {
 }
 
 .schedule-action {
-    margin-top: 4px;
+    margin-top: 12px;
     display: flex;
+    width: 100%;
+}
+
+.schedule-card-main .schedule-action {
+    align-self: stretch;
+    justify-content: flex-end;
 }
 
 .schedule-card-footer {


### PR DESCRIPTION
## Summary
- move the create order button into the visible section of schedule cards
- update schedule card layout styles so the button stays aligned when the card is collapsed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc498b07d48333bc076c6979322062