### PR TITLE
Move schedule action button to collapsed schedule card

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -1625,6 +1625,18 @@ class ScheduleManager {
                             </div>
                         </div>
                     </div>
+
+                    <div class="schedule-action">
+                        <button
+                            type="button"
+                            class="create-order-btn"
+                            data-group-key="${safeGroupIdentifier}"
+                            data-schedule-id="${safeScheduleId}"
+                        >
+                            <i class="fas fa-plus"></i>
+                            Создать заявку
+                        </button>
+                    </div>
                 </div>
 
                 <div class="schedule-card-extra" id="${extraSectionId}" aria-hidden="true">
@@ -1650,18 +1662,6 @@ class ScheduleManager {
                             <span class="meta-label">Города</span>
                             <span class="meta-value">${citiesSummary}</span>
                         </div>
-                    </div>
-
-                    <div class="schedule-action">
-                        <button
-                            type="button"
-                            class="create-order-btn"
-                            data-group-key="${safeGroupIdentifier}"
-                            data-schedule-id="${safeScheduleId}"
-                        >
-                            <i class="fas fa-plus"></i>
-                            Создать заявку
-                        </button>
                     </div>
                 </div>
 

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -1160,8 +1160,8 @@ body {
 .schedule-card-main {
     display: flex;
     flex-direction: column;
-    gap: 14px;
-    padding: 20px 20px 16px;
+    gap: 18px;
+    padding: 20px;
 }
 
 .schedule-card-header {
@@ -1307,8 +1307,13 @@ body {
 }
 
 .schedule-action {
-    margin-top: 4px;
     display: flex;
+    align-items: stretch;
+    width: 100%;
+}
+
+.schedule-card-main .schedule-action {
+    margin-top: 0;
 }
 
 .schedule-card-footer {
@@ -1479,6 +1484,7 @@ body {
 
 .schedule-card .create-order-btn {
     width: 100%;
+    min-height: 52px;
 }
 
 .orders-grid {


### PR DESCRIPTION
## Summary
- show the create order action within the main schedule card content so it is visible without expanding
- refresh schedule card spacing so the button fits the collapsed layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc4e731e6483339e299dba4f2d29a3