### PR TITLE
Обновить стили клиентского модального окна заявки

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -198,6 +198,9 @@ body.city-confirm-open {
 /* Улучшенная анимация появления */
 #clientRequestModal {
     --modal-timing: cubic-bezier(0.34, 1.56, 0.64, 1);
+    --request-modal-accent: var(--primary);
+    --request-modal-border: var(--border);
+    --request-modal-soft-bg: color-mix(in srgb, var(--primary), transparent 82%);
 }
 
 #clientRequestModal .modal-content {
@@ -268,6 +271,220 @@ body.city-confirm-open {
     flex: 1;
     max-height: none;
     overflow-y: auto;
+}
+
+#clientRequestModal .request-modal__summary {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(16px, 3vw, 24px);
+    padding: clamp(22px, 4vw, 30px);
+    border-radius: clamp(20px, 5vw, 28px);
+    border: 1px solid color-mix(in srgb, var(--request-modal-border) 60%, transparent);
+    background: linear-gradient(
+        135deg,
+        color-mix(in srgb, var(--primary) 12%, rgba(255, 255, 255, 0.98)) 0%,
+        var(--bg-primary, #ffffff) 80%
+    );
+    box-shadow:
+        0 24px 48px rgba(15, 23, 42, 0.12),
+        0 20px 60px -40px color-mix(in srgb, var(--primary) 45%, transparent);
+    overflow: hidden;
+}
+
+#clientRequestModal .request-modal__summary::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+        circle at 95% 12%,
+        color-mix(in srgb, var(--primary) 28%, transparent) 0%,
+        transparent 55%
+    );
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+#clientRequestModal .request-modal__summary > * {
+    position: relative;
+    z-index: 1;
+}
+
+#clientRequestModal .request-modal__summary .modal-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: clamp(12px, 3vw, 24px);
+    padding: clamp(18px, 3.5vw, 24px) clamp(20px, 4vw, 28px);
+    padding-left: clamp(88px, 12vw, 112px);
+    border-radius: clamp(18px, 4vw, 22px);
+    border: 1px solid color-mix(in srgb, var(--request-modal-border) 45%, transparent);
+    background: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.96) 0%,
+        color-mix(in srgb, var(--primary) 8%, rgba(255, 255, 255, 0.92)) 100%
+    );
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    position: relative;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+#clientRequestModal .request-modal__summary .modal-row:hover {
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--primary) 40%, transparent);
+    box-shadow: 0 22px 40px rgba(15, 23, 42, 0.12);
+}
+
+#clientRequestModal .request-modal__summary .modal-row::before {
+    content: "";
+    position: absolute;
+    left: clamp(20px, 4vw, 30px);
+    top: 50%;
+    transform: translateY(-50%);
+    width: clamp(54px, 7vw, 64px);
+    height: clamp(54px, 7vw, 64px);
+    border-radius: 18px;
+    background-image: linear-gradient(135deg, var(--primary) 0%, color-mix(in srgb, var(--primary) 55%, transparent) 100%);
+    box-shadow: 0 18px 32px color-mix(in srgb, var(--primary) 42%, transparent);
+}
+
+#clientRequestModal .request-modal__summary .modal-row::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: calc(clamp(20px, 4vw, 30px) + clamp(54px, 7vw, 64px) / 2);
+    transform: translate(-50%, -50%);
+    width: clamp(26px, 4vw, 32px);
+    height: clamp(26px, 4vw, 32px);
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+}
+
+#clientRequestModal .request-modal__summary .modal-row:first-child::after {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 12h11'/%3E%3Cpath d='M13 8l5 4-5 4'/%3E%3Cpath d='M4 5h5'/%3E%3Cpath d='M4 19h5'/%3E%3C/svg%3E");
+}
+
+#clientRequestModal .request-modal__summary .modal-row:last-child::after {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='17' rx='2'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3Cpath d='M8 14h4v4H8z' fill='%23ffffff' stroke='none'/%3E%3C/svg%3E");
+}
+
+#clientRequestModal .request-modal__summary .modal-label {
+    font-size: clamp(0.95rem, 0.4vw + 0.9rem, 1.1rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--text-secondary, #475569) 80%, var(--text-primary, #0f172a) 20%);
+    flex: 1 1 220px;
+}
+
+#clientRequestModal .request-modal__summary .modal-value {
+    font-size: clamp(1.1rem, 0.6vw + 1rem, 1.45rem);
+    font-weight: 700;
+    color: color-mix(in srgb, var(--request-modal-accent) 85%, var(--text-primary, #0f172a) 15%);
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+    flex: 1 1 260px;
+}
+
+#clientRequestModal .request-modal__selection {
+    display: flex;
+    align-items: stretch;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: clamp(18px, 4vw, 28px);
+    margin-top: clamp(18px, 4vw, 26px);
+    padding: clamp(24px, 5vw, 32px);
+    border-radius: clamp(22px, 5vw, 30px);
+    border: 1px solid color-mix(in srgb, var(--request-modal-border) 55%, transparent);
+    background: linear-gradient(
+        135deg,
+        color-mix(in srgb, var(--primary) 12%, rgba(255, 255, 255, 0.95)) 0%,
+        var(--bg-primary, #ffffff) 80%
+    );
+    box-shadow:
+        0 24px 48px rgba(15, 23, 42, 0.1),
+        0 20px 56px -34px color-mix(in srgb, var(--primary) 45%, transparent);
+    position: relative;
+    overflow: hidden;
+}
+
+#clientRequestModal .request-modal__selection::before {
+    content: "";
+    position: absolute;
+    inset: -40% 45% auto -20%;
+    height: 140%;
+    background: radial-gradient(circle, color-mix(in srgb, var(--primary) 22%, transparent) 0%, transparent 60%);
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+#clientRequestModal .request-modal__selection-info {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: clamp(18px, 4vw, 32px);
+}
+
+#clientRequestModal .request-modal__selection-item {
+    min-width: clamp(220px, 30vw, 260px);
+    padding: clamp(16px, 4vw, 22px);
+    border-radius: clamp(16px, 4vw, 22px);
+    border: 1px solid color-mix(in srgb, var(--request-modal-border) 50%, transparent);
+    background: rgba(255, 255, 255, 0.82);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+#clientRequestModal .request-modal__selection-label {
+    font-size: clamp(0.8rem, 0.35vw + 0.8rem, 0.95rem);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--text-secondary, #475569) 85%, var(--text-primary, #0f172a) 15%);
+}
+
+#clientRequestModal .request-modal__selection-value {
+    font-size: clamp(1.05rem, 0.6vw + 1rem, 1.35rem);
+    font-weight: 700;
+    color: color-mix(in srgb, var(--request-modal-accent) 82%, var(--text-primary, #0f172a) 18%);
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+#clientRequestModal .request-modal__selection-change {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: clamp(13px, 3.5vw, 16px) clamp(24px, 5vw, 32px);
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: linear-gradient(135deg, var(--primary) 0%, color-mix(in srgb, var(--primary) 50%, transparent) 100%);
+    color: #ffffff;
+    font-size: clamp(0.95rem, 0.35vw + 0.95rem, 1.05rem);
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 20px 38px color-mix(in srgb, var(--primary) 45%, transparent);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+    text-decoration: none;
+}
+
+#clientRequestModal .request-modal__selection-change::before {
+    content: "";
+    width: clamp(18px, 3.5vw, 22px);
+    height: clamp(18px, 3.5vw, 22px);
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 17.5 5.5 20 8 18.5 18.3 8.2a2.1 2.1 0 0 0 0-3L17 3.9a2.1 2.1 0 0 0-3 0L3.7 14.3 3 17z'/%3E%3Cpath d='m14.5 5.5 4 4'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+
+#clientRequestModal .request-modal__selection-change:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 24px 48px color-mix(in srgb, var(--primary) 50%, transparent);
+    filter: brightness(1.05);
+}
+
+#clientRequestModal .request-modal__selection-change:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--primary) 35%, transparent), 0 20px 38px color-mix(in srgb, var(--primary) 45%, transparent);
 }
 
 #clientRequestModal.active {
@@ -1127,6 +1344,46 @@ body.city-confirm-open {
     padding: var(--client-modal-spacing);
     margin: 0;
   }
+
+  #clientRequestModal .request-modal__summary {
+    padding: clamp(20px, 6vw, 26px);
+    gap: clamp(14px, 5vw, 22px);
+  }
+
+  #clientRequestModal .request-modal__summary .modal-row {
+    padding: clamp(18px, 5vw, 24px) clamp(18px, 5vw, 24px);
+    padding-left: clamp(78px, 18vw, 98px);
+  }
+
+  #clientRequestModal .request-modal__summary .modal-row::before {
+    left: clamp(18px, 6vw, 26px);
+    width: clamp(48px, 11vw, 56px);
+    height: clamp(48px, 11vw, 56px);
+  }
+
+  #clientRequestModal .request-modal__summary .modal-row::after {
+    left: calc(clamp(18px, 6vw, 26px) + clamp(48px, 11vw, 56px) / 2);
+    width: clamp(24px, 6vw, 30px);
+    height: clamp(24px, 6vw, 30px);
+  }
+
+  #clientRequestModal .request-modal__selection {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  #clientRequestModal .request-modal__selection-info {
+    gap: clamp(16px, 5vw, 26px);
+  }
+
+  #clientRequestModal .request-modal__selection-item {
+    min-width: 100%;
+  }
+
+  #clientRequestModal .request-modal__selection-change {
+    width: 100%;
+    align-self: stretch;
+  }
 }
 
 /* Улучшенная адаптивность */
@@ -1181,11 +1438,58 @@ body.city-confirm-open {
     transform: translateX(22px);
   }
 
-  #clientRequestModal .filter-step {
+  #clientRequestModal .filter-step { 
     padding: 14px;
   }
 
   #clientRequestModal .filter-step-action {
     font-size: 0.9rem;
+  }
+
+  #clientRequestModal .request-modal__summary {
+    padding: clamp(18px, 7vw, 24px);
+    gap: clamp(14px, 7vw, 20px);
+  }
+
+  #clientRequestModal .request-modal__summary .modal-row {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: clamp(16px, 7vw, 22px) clamp(16px, 7vw, 22px);
+    padding-left: clamp(64px, 18vw, 84px);
+  }
+
+  #clientRequestModal .request-modal__summary .modal-row::before {
+    left: clamp(14px, 6vw, 22px);
+    width: clamp(44px, 14vw, 52px);
+    height: clamp(44px, 14vw, 52px);
+    border-radius: 16px;
+  }
+
+  #clientRequestModal .request-modal__summary .modal-row::after {
+    left: calc(clamp(14px, 6vw, 22px) + clamp(44px, 14vw, 52px) / 2);
+  }
+
+  #clientRequestModal .request-modal__summary .modal-value {
+    text-align: left;
+    font-size: clamp(1.05rem, 1vw + 1rem, 1.3rem);
+  }
+
+  #clientRequestModal .request-modal__selection {
+    padding: clamp(20px, 8vw, 26px);
+    gap: clamp(16px, 6vw, 24px);
+  }
+
+  #clientRequestModal .request-modal__selection-item {
+    padding: clamp(14px, 6vw, 20px);
+  }
+
+  #clientRequestModal .request-modal__selection-change {
+    border-radius: clamp(18px, 7vw, 24px);
+    padding: clamp(14px, 6vw, 18px) clamp(20px, 8vw, 28px);
+  }
+
+  #clientRequestModal .request-modal__selection-change::before {
+    width: clamp(18px, 6vw, 24px);
+    height: clamp(18px, 6vw, 24px);
   }
 }


### PR DESCRIPTION
## Summary
- настроены клиентские переменные модального окна на основную цветовую схему
- переработан блок резюме, карточки выбора маркетплейса/склада и кнопка изменения с новыми градиентами, типографикой и иконками
- обновлены медиазапросы для аккуратного отображения карточек на планшетах и телефонах

## Testing
- not run (CSS changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc6008ba348333aaab05e358273827