### PR TITLE
Упростить оформление модального окна клиента

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -240,30 +240,29 @@ body.city-confirm-open {
     width: 40px;
     height: 40px;
     border-radius: 999px;
-    border: 1px solid transparent;
-    background: var(--bg-tertiary, #f3f4f6);
-    color: var(--text-secondary, #6b7280);
+    border: 1px solid var(--border, #d1d5db);
+    background: #ffffff;
+    color: var(--text-primary, #111827);
     cursor: pointer;
     font-size: 1.75rem;
     line-height: 1;
-    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.12);
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
 #clientRequestModal .modal-close-btn:hover {
-    background: var(--primary, #28C76F);
-    color: #ffffff;
-    transform: translateY(-1px) scale(1.03);
-    box-shadow: 0 8px 20px rgba(40, 199, 111, 0.3);
+    background: #f1f5f9;
+    border-color: var(--primary, #28C76F);
+    color: var(--text-primary, #111827);
 }
 
 #clientRequestModal .modal-close-btn:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 4px rgba(40, 199, 111, 0.25);
+    box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.25);
 }
 
 #clientRequestModal .modal-close-btn:active {
-    transform: scale(0.94);
+    background: #e2e8f0;
 }
 
 #clientRequestModal .request-modal__body {
@@ -281,8 +280,8 @@ body.city-confirm-open {
     padding: clamp(22px, 4vw, 30px);
     border-radius: clamp(20px, 5vw, 28px);
     border: 1px solid var(--border, #e2e8f0);
-    background: var(--bg-primary, #ffffff);
-    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+    background: #ffffff;
+    box-shadow: none;
 }
 
 #clientRequestModal .request-modal__summary > * {
@@ -298,15 +297,14 @@ body.city-confirm-open {
     padding: clamp(18px, 3.5vw, 24px) clamp(20px, 4vw, 28px);
     border-radius: clamp(16px, 4vw, 20px);
     border: 1px solid var(--border, #e2e8f0);
-    background: var(--bg-primary, #ffffff);
-    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
-    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+    background: #ffffff;
+    box-shadow: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 #clientRequestModal .request-modal__summary .modal-row:hover {
-    transform: translateY(-2px);
-    border-color: rgba(40, 199, 111, 0.35);
-    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+    border-color: var(--primary, #28C76F);
+    background: #f8fafc;
 }
 
 #clientRequestModal .request-modal__summary .modal-row-icon {
@@ -362,27 +360,9 @@ body.city-confirm-open {
     margin-top: clamp(18px, 4vw, 26px);
     padding: clamp(24px, 5vw, 32px);
     border-radius: clamp(22px, 5vw, 30px);
-    border: 1px solid color-mix(in srgb, var(--request-modal-border) 55%, transparent);
-    background: linear-gradient(
-        135deg,
-        color-mix(in srgb, var(--primary) 12%, rgba(255, 255, 255, 0.95)) 0%,
-        var(--bg-primary, #ffffff) 80%
-    );
-    box-shadow:
-        0 24px 48px rgba(15, 23, 42, 0.1),
-        0 20px 56px -34px color-mix(in srgb, var(--primary) 45%, transparent);
-    position: relative;
-    overflow: hidden;
-}
-
-#clientRequestModal .request-modal__selection::before {
-    content: "";
-    position: absolute;
-    inset: -40% 45% auto -20%;
-    height: 140%;
-    background: radial-gradient(circle, color-mix(in srgb, var(--primary) 22%, transparent) 0%, transparent 60%);
-    opacity: 0.45;
-    pointer-events: none;
+    border: 1px solid var(--border, #e2e8f0);
+    background: #ffffff;
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
 }
 
 #clientRequestModal .request-modal__selection-info {
@@ -397,9 +377,9 @@ body.city-confirm-open {
     min-width: clamp(220px, 30vw, 260px);
     padding: clamp(16px, 4vw, 22px);
     border-radius: clamp(16px, 4vw, 22px);
-    border: 1px solid color-mix(in srgb, var(--request-modal-border) 50%, transparent);
-    background: rgba(255, 255, 255, 0.82);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    border: 1px solid var(--border, #e2e8f0);
+    background: #ffffff;
+    box-shadow: none;
 }
 
 #clientRequestModal .request-modal__selection-label {
@@ -413,7 +393,7 @@ body.city-confirm-open {
     font-size: clamp(1.05rem, 0.6vw + 1rem, 1.35rem);
     font-weight: 700;
     color: color-mix(in srgb, var(--request-modal-accent) 82%, var(--text-primary, #0f172a) 18%);
-    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+    text-shadow: none;
 }
 
 #clientRequestModal .request-modal__selection-change {
@@ -425,33 +405,26 @@ body.city-confirm-open {
     gap: 10px;
     padding: clamp(13px, 3.5vw, 16px) clamp(24px, 5vw, 32px);
     border-radius: 999px;
-    border: 1px solid transparent;
-    background: linear-gradient(135deg, var(--primary) 0%, color-mix(in srgb, var(--primary) 50%, transparent) 100%);
+    border: 1px solid var(--primary, #28C76F);
+    background: var(--primary, #28C76F);
     color: #ffffff;
     font-size: clamp(0.95rem, 0.35vw + 0.95rem, 1.05rem);
     font-weight: 600;
     cursor: pointer;
-    box-shadow: 0 20px 38px color-mix(in srgb, var(--primary) 45%, transparent);
-    transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+    box-shadow: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
     text-decoration: none;
 }
 
-#clientRequestModal .request-modal__selection-change::before {
-    content: "";
-    width: clamp(18px, 3.5vw, 22px);
-    height: clamp(18px, 3.5vw, 22px);
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 17.5 5.5 20 8 18.5 18.3 8.2a2.1 2.1 0 0 0 0-3L17 3.9a2.1 2.1 0 0 0-3 0L3.7 14.3 3 17z'/%3E%3Cpath d='m14.5 5.5 4 4'/%3E%3C/svg%3E") center / contain no-repeat;
-}
-
 #clientRequestModal .request-modal__selection-change:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 24px 48px color-mix(in srgb, var(--primary) 50%, transparent);
-    filter: brightness(1.05);
+    background: color-mix(in srgb, var(--primary, #28C76F) 88%, black 12%);
+    border-color: color-mix(in srgb, var(--primary, #28C76F) 88%, black 12%);
+    box-shadow: none;
 }
 
 #clientRequestModal .request-modal__selection-change:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--primary) 35%, transparent), 0 20px 38px color-mix(in srgb, var(--primary) 45%, transparent);
+    box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.3);
 }
 
 #clientRequestModal.active {
@@ -566,38 +539,27 @@ body.city-confirm-open {
   padding: 16px 18px;
   border: 1px solid var(--border, #e5e7eb);
   border-radius: var(--radius, 8px);
-  background: var(--bg-secondary, #f9fafb);
+  background: #ffffff;
   cursor: pointer;
-  transition: var(--transition, all 0.3s ease);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   position: relative;
-  overflow: hidden;
-}
-
-.request-form__option::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 0;
-  height: 100%;
-  background: linear-gradient(90deg, rgba(40, 199, 111, 0.1), transparent);
-  transition: width 0.3s ease;
 }
 
 .request-form__option:hover {
-  background: var(--bg-tertiary, #f3f4f6);
+  background: #f8fafc;
   border-color: var(--primary, #28C76F);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(40, 199, 111, 0.15);
-}
-
-.request-form__option:hover::before {
-  width: 100%;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
 }
 
 .request-form__option:focus-within {
   border-color: var(--primary, #28C76F);
   box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.2);
+}
+
+.request-form__option:has(.form-radio:checked) {
+  border-color: var(--primary, #28C76F);
+  background: #ecfdf5;
+  box-shadow: 0 0 0 1px rgba(40, 199, 111, 0.2);
 }
 
 .request-form__option-label {
@@ -609,47 +571,19 @@ body.city-confirm-open {
   z-index: 1;
 }
 
+.request-form__option:has(.form-radio:checked) .request-form__option-label,
 .request-form__option .form-radio:checked + .request-form__option-label {
-  font-weight: 700;
+  font-weight: 600;
   color: var(--primary, #28C76F);
 }
 
 .form-radio {
-  appearance: none;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  border: 2px solid var(--border, #e5e7eb);
-  background: #fff;
-  display: grid;
-  place-items: center;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  position: relative;
-  z-index: 1;
-}
-
-.form-radio::after {
-  content: "";
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--primary, #28C76F);
-  transform: scale(0);
-  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.form-radio:checked {
-  border-color: var(--primary, #28C76F);
-  box-shadow: 0 0 0 2px rgba(40, 199, 111, 0.2);
-}
-
-.form-radio:checked::after {
-  transform: scale(1);
-}
-
-.form-radio:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.3);
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 1px;
+  height: 1px;
+  margin: 0;
 }
 
 .request-form__dimensions,
@@ -728,23 +662,6 @@ body.city-confirm-open {
   position: relative;
 }
 
-.request-form__box-group::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 4px;
-  height: 100%;
-  background: var(--primary, #28C76F);
-  border-radius: var(--radius, 8px) 0 0 var(--radius, 8px);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.request-form__box-group:hover::before {
-  opacity: 1;
-}
-
 .request-form__box-group-title {
   font-weight: 600;
   color: var(--text-primary, #1f2937);
@@ -792,20 +709,13 @@ body.city-confirm-open {
   gap: 8px;
 }
 
-.request-form__warning::before,
-.form-error::before,
-.text-danger::before {
-  content: '⚠️';
-  font-size: 1rem;
-}
-
 .request-form__summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 16px 20px;
-  background: linear-gradient(135deg, var(--bg-secondary, #f9fafb) 0%, var(--bg-tertiary, #f3f4f6) 100%);
+  background: #ffffff;
   border: 1px solid var(--border, #e5e7eb);
   border-radius: var(--radius, 8px);
   margin: 8px 0;
@@ -817,11 +727,6 @@ body.city-confirm-open {
   display: flex;
   align-items: center;
   gap: 8px;
-}
-
-.request-form__summary label::before {
-  content: '💰';
-  font-size: 1rem;
 }
 
 .request-form__summary-value {
@@ -838,33 +743,14 @@ body.city-confirm-open {
   padding: 16px 20px;
   border: 1px solid var(--border, #e5e7eb);
   border-radius: var(--radius, 8px);
-  background: var(--bg-secondary, #f9fafb);
+  background: #ffffff;
   cursor: pointer;
-  transition: var(--transition, all 0.3s ease);
-  position: relative;
-  overflow: hidden;
-}
-
-.request-form__switch::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(40, 199, 111, 0.05), transparent);
-  transition: left 0.6s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .request-form__switch:hover {
-  background: var(--bg-tertiary, #f3f4f6);
+  background: #f8fafc;
   border-color: var(--primary, #28C76F);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(40, 199, 111, 0.15);
-}
-
-.request-form__switch:hover::before {
-  left: 100%;
 }
 
 .request-form__switch:focus-within {
@@ -891,9 +777,9 @@ body.city-confirm-open {
   height: 28px;
   border-radius: 9999px;
   background: var(--border, #d1d5db);
-  transition: all 0.3s ease;
+  transition: background-color 0.2s ease;
   flex-shrink: 0;
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: none;
 }
 
 .form-switch__control::after {
@@ -905,18 +791,16 @@ body.city-confirm-open {
   height: 24px;
   border-radius: 50%;
   background: #fff;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: none;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .form-switch__input:checked + .form-switch__control {
   background: var(--primary, #28C76F);
-  box-shadow: 0 0 0 2px rgba(40, 199, 111, 0.2);
 }
 
 .form-switch__input:checked + .form-switch__control::after {
   transform: translateX(24px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 .form-switch__input:focus-visible + .form-switch__control {
@@ -941,15 +825,14 @@ body.city-confirm-open {
   width: 100%;
   border: 1px solid var(--border, #e5e7eb);
   border-radius: var(--radius-lg, 12px);
-  background: var(--bg-primary, #ffffff);
-  box-shadow: var(--shadow-lg, 0 10px 25px rgba(0, 0, 0, 0.1));
+  background: #ffffff;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
   overflow: hidden;
-  transition: all 0.3s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .request-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.15);
   border-color: var(--primary, #28C76F);
 }
 
@@ -1164,41 +1047,25 @@ body.city-confirm-open {
   align-items: center;
   gap: 12px;
   padding: 16px 24px;
-  background: linear-gradient(135deg, var(--primary, #28C76F) 0%, #1e9553 100%);
-  color: white;
-  border: none;
+  background: var(--primary, #28C76F);
+  color: #ffffff;
+  border: 1px solid var(--primary, #28C76F);
   border-radius: var(--radius-lg, 12px);
   font-size: 1.1rem;
   font-weight: 700;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   position: relative;
-  overflow: hidden;
-  box-shadow: 0 4px 15px rgba(40, 199, 111, 0.3);
-}
-
-.request-form__actions .primary-button::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-  transition: left 0.6s ease;
 }
 
 .request-form__actions .primary-button:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 25px rgba(40, 199, 111, 0.4);
-}
-
-.request-form__actions .primary-button:hover::before {
-  left: 100%;
+  background: color-mix(in srgb, var(--primary, #28C76F) 88%, black 12%);
+  border-color: color-mix(in srgb, var(--primary, #28C76F) 88%, black 12%);
+  box-shadow: none;
 }
 
 .request-form__actions .primary-button:active {
-  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--primary, #28C76F) 80%, black 20%);
 }
 
 .request-form__submit {
@@ -1207,7 +1074,7 @@ body.city-confirm-open {
 
 .request-form__actions .primary-button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 4px rgba(40, 199, 111, 0.3);
+  box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.3);
 }
 
 .button__label {
@@ -1441,10 +1308,5 @@ body.city-confirm-open {
   #clientRequestModal .request-modal__selection-change {
     border-radius: clamp(18px, 7vw, 24px);
     padding: clamp(14px, 6vw, 18px) clamp(20px, 8vw, 28px);
-  }
-
-  #clientRequestModal .request-modal__selection-change::before {
-    width: clamp(18px, 6vw, 24px);
-    height: clamp(18px, 6vw, 24px);
   }
 }


### PR DESCRIPTION
## Summary
- перешёл на однотонное оформление для кнопки закрытия модалки, блоков краткой информации и выбора тарифа, убрав массивные тени и декоративные элементы
- очистил псевдоэлементы и текстовые тени, упростил стили кнопок смены выбора и отправки заявки
- спрятал стандартные кружки радиокнопок и подсвечиваю выбранную карточку через псевдокласс :has(:checked)

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cc7fe226708333bc36cd1ddf401b5d