### PR TITLE
Tighten request modal summary layout

### DIFF
--- a/styles/components.css
+++ b/styles/components.css
@@ -396,11 +396,12 @@
 .request-modal__summary {
     display: flex;
     flex-direction: column;
-    gap: var(--request-modal-spacing-sm);
-    padding: var(--request-modal-spacing-sm);
+    gap: 0;
+    padding: 0;
     border: 1px solid var(--request-modal-border);
     border-radius: var(--request-modal-radius-lg);
     background: var(--request-modal-surface);
+    overflow: hidden;
 }
 
 .request-modal__selection {
@@ -491,12 +492,18 @@
 }
 
 .request-modal__summary .modal-row {
-    border-color: var(--request-modal-border);
+    border: none;
+    border-bottom: 1px solid var(--request-modal-border);
+    border-radius: 0;
+}
+
+.request-modal__summary .modal-row:last-child {
+    border-bottom: none;
 }
 
 .request-modal__summary .modal-row:hover {
-    border-color: var(--request-modal-accent);
     background: var(--request-modal-soft-bg);
+    box-shadow: inset 0 0 0 1px var(--request-modal-accent);
 }
 
 .request-modal .modal-label {


### PR DESCRIPTION
## Summary
- remove extra spacing inside the request modal summary so cards fit the flat surface border
- add inline separators and hover emphasis for summary rows to stay legible without external gaps

## Testing
- Manually previewed request modal at 320, 375 and desktop widths

------
https://chatgpt.com/codex/tasks/task_e_68cc87266cc0833397891f951c68b1b3