### PR TITLE
Reduce request modal spacing

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -276,9 +276,9 @@ body.city-confirm-open {
     position: relative;
     display: flex;
     flex-direction: column;
-    gap: clamp(16px, 3vw, 24px);
-    padding: clamp(22px, 4vw, 30px);
-    border-radius: clamp(20px, 5vw, 28px);
+    gap: clamp(12px, 2.4vw, 18px);
+    padding: clamp(18px, 3vw, 24px);
+    border-radius: clamp(16px, 4vw, 24px);
     border: 1px solid var(--border, #e2e8f0);
     background: #ffffff;
     box-shadow: none;
@@ -293,9 +293,9 @@ body.city-confirm-open {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: clamp(12px, 3vw, 18px);
-    padding: clamp(18px, 3.5vw, 24px) clamp(20px, 4vw, 28px);
-    border-radius: clamp(16px, 4vw, 20px);
+    gap: clamp(10px, 2.5vw, 14px);
+    padding: clamp(14px, 3vw, 20px) clamp(16px, 3.2vw, 22px);
+    border-radius: clamp(14px, 3.5vw, 18px);
     border: 1px solid var(--border, #e2e8f0);
     background: #ffffff;
     box-shadow: none;
@@ -356,10 +356,10 @@ body.city-confirm-open {
     align-items: stretch;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap: clamp(18px, 4vw, 28px);
+    gap: clamp(14px, 3.5vw, 22px);
     margin-top: clamp(18px, 4vw, 26px);
-    padding: clamp(24px, 5vw, 32px);
-    border-radius: clamp(22px, 5vw, 30px);
+    padding: clamp(18px, 4vw, 26px);
+    border-radius: clamp(18px, 4vw, 26px);
     border: 1px solid var(--border, #e2e8f0);
     background: #ffffff;
     box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
@@ -375,8 +375,8 @@ body.city-confirm-open {
 
 #clientRequestModal .request-modal__selection-item {
     min-width: clamp(220px, 30vw, 260px);
-    padding: clamp(16px, 4vw, 22px);
-    border-radius: clamp(16px, 4vw, 22px);
+    padding: clamp(14px, 3.5vw, 18px);
+    border-radius: clamp(14px, 3.5vw, 18px);
     border: 1px solid var(--border, #e2e8f0);
     background: #ffffff;
     box-shadow: none;
@@ -402,9 +402,9 @@ body.city-confirm-open {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 10px;
-    padding: clamp(13px, 3.5vw, 16px) clamp(24px, 5vw, 32px);
-    border-radius: 999px;
+    gap: 8px;
+    padding: clamp(11px, 3vw, 14px) clamp(20px, 4.5vw, 26px);
+    border-radius: clamp(18px, 5vw, 26px);
     border: 1px solid var(--primary, #28C76F);
     background: var(--primary, #28C76F);
     color: #ffffff;
@@ -1180,12 +1180,12 @@ body.city-confirm-open {
   }
 
   #clientRequestModal .request-modal__summary {
-    padding: clamp(20px, 6vw, 26px);
-    gap: clamp(14px, 5vw, 22px);
+    padding: clamp(16px, 5vw, 22px);
+    gap: clamp(12px, 4.5vw, 18px);
   }
 
   #clientRequestModal .request-modal__summary .modal-row {
-    padding: clamp(18px, 5vw, 24px) clamp(18px, 5vw, 24px);
+    padding: clamp(12px, 4.5vw, 18px) clamp(14px, 4.8vw, 20px);
     align-items: flex-start;
   }
 
@@ -1197,6 +1197,9 @@ body.city-confirm-open {
   #clientRequestModal .request-modal__selection {
     flex-direction: column;
     align-items: stretch;
+    padding: clamp(16px, 5vw, 24px);
+    gap: clamp(12px, 5vw, 20px);
+    border-radius: clamp(16px, 5vw, 24px);
   }
 
   #clientRequestModal .request-modal__selection-info {
@@ -1205,11 +1208,16 @@ body.city-confirm-open {
 
   #clientRequestModal .request-modal__selection-item {
     min-width: 100%;
+    padding: clamp(12px, 5vw, 18px);
+    border-radius: clamp(12px, 5vw, 18px);
   }
 
   #clientRequestModal .request-modal__selection-change {
     width: 100%;
     align-self: stretch;
+    gap: 8px;
+    padding: clamp(10px, 4.5vw, 14px) clamp(18px, 6vw, 24px);
+    border-radius: clamp(16px, 6vw, 24px);
   }
 }
 
@@ -1274,14 +1282,14 @@ body.city-confirm-open {
   }
 
   #clientRequestModal .request-modal__summary {
-    padding: clamp(18px, 7vw, 24px);
-    gap: clamp(14px, 7vw, 20px);
+    padding: clamp(14px, 6.5vw, 20px);
+    gap: clamp(12px, 6.5vw, 18px);
   }
 
   #clientRequestModal .request-modal__summary .modal-row {
     flex-direction: column;
     align-items: flex-start;
-    padding: clamp(16px, 7vw, 22px) clamp(16px, 7vw, 22px);
+    padding: clamp(12px, 6.5vw, 18px) clamp(12px, 6.5vw, 18px);
   }
 
   #clientRequestModal .request-modal__summary .modal-row-icon {
@@ -1297,16 +1305,16 @@ body.city-confirm-open {
   }
 
   #clientRequestModal .request-modal__selection {
-    padding: clamp(20px, 8vw, 26px);
-    gap: clamp(16px, 6vw, 24px);
+    padding: clamp(16px, 7vw, 22px);
+    gap: clamp(12px, 6.5vw, 20px);
   }
 
   #clientRequestModal .request-modal__selection-item {
-    padding: clamp(14px, 6vw, 20px);
+    padding: clamp(12px, 5.5vw, 16px);
   }
 
   #clientRequestModal .request-modal__selection-change {
-    border-radius: clamp(18px, 7vw, 24px);
-    padding: clamp(14px, 6vw, 18px) clamp(20px, 8vw, 28px);
+    border-radius: clamp(14px, 6.5vw, 20px);
+    padding: clamp(12px, 6vw, 16px) clamp(18px, 7vw, 24px);
   }
 }


### PR DESCRIPTION
## Summary
- reduce the desktop request modal summary and selection card spacing so the cards sit lower and take up less height.
- update the tablet and phone media query spacings for the same blocks to keep the modal compact on smaller screens.

## Testing
- echo "No automated tests were run; UI change only."


------
https://chatgpt.com/codex/tasks/task_e_68cc8b425374833382427816639f4b67