### PR TITLE
Highlight city selection area in client request modal

### DIFF
--- a/styles/componentsclient.css
+++ b/styles/componentsclient.css
@@ -272,10 +272,40 @@
     color: var(--text-secondary);
 }
 
+
 .request-form__city-group {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: var(--spacing-sm);
+    padding: calc(var(--spacing-lg) - var(--spacing-xs)) var(--spacing-lg);
+    border: 1.5px solid rgba(5, 150, 105, 0.4);
+    border-radius: var(--radius-lg);
+    background: linear-gradient(135deg, rgba(5, 150, 105, 0.12), rgba(5, 150, 105, 0.04));
+    box-shadow: 0 18px 28px -22px rgba(5, 150, 105, 0.6);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.request-form__city-group::after {
+    content: "📍";
+    position: absolute;
+    top: var(--spacing-md);
+    right: var(--spacing-md);
+    font-size: 1.25rem;
+    line-height: 1;
+    opacity: 0.65;
+    pointer-events: none;
+}
+
+.request-form__city-group > label {
+    font-weight: 600;
+    color: var(--primary);
+}
+
+.request-form__city-group:focus-within {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 4px rgba(5, 150, 105, 0.18);
+    background: linear-gradient(135deg, rgba(5, 150, 105, 0.18), rgba(5, 150, 105, 0.06));
 }
 
 .request-form__city-control {
@@ -287,12 +317,46 @@
 .request-form__city-select {
     width: 100%;
     min-width: 0;
+    border-width: 2px;
+    border-color: rgba(5, 150, 105, 0.45);
+    font-weight: 600;
+    background: rgba(5, 150, 105, 0.1);
+    box-shadow: inset 0 1px 2px rgba(17, 24, 39, 0.08);
+}
+
+.request-form__city-select:hover {
+    border-color: var(--primary);
+}
+
+.request-form__city-select:focus {
+    background: var(--bg-white);
+}
+
+#citySelectionNotice {
+    margin: calc(-1 * var(--spacing-sm)) 0 var(--spacing-xl);
+    padding: var(--spacing-md) calc(var(--spacing-lg) + var(--spacing-sm));
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(5, 150, 105, 0.35);
+    background: linear-gradient(135deg, rgba(5, 150, 105, 0.12), rgba(5, 150, 105, 0.02));
+    color: var(--primary);
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+#citySelectionNotice::before {
+    content: "ℹ";
+    font-size: 1.125rem;
+    line-height: 1;
 }
 
 @media (min-width: 768px) {
     .request-form__city-group {
         flex-direction: row;
         align-items: center;
+        padding: var(--spacing-lg) calc(var(--spacing-xl) + var(--spacing-sm));
     }
 
     .request-form__city-group > label {
@@ -302,6 +366,26 @@
 
     .request-form__city-control {
         flex: 1;
+    }
+
+    #citySelectionNotice {
+        margin: calc(-1 * var(--spacing-sm)) 0 var(--spacing-xl) calc(var(--spacing-lg) + var(--spacing-sm));
+    }
+}
+
+@media (max-width: 520px) {
+    .request-form__city-group {
+        padding: var(--spacing-md) var(--spacing-md);
+    }
+
+    .request-form__city-group::after {
+        top: var(--spacing-sm);
+        right: var(--spacing-sm);
+    }
+
+    #citySelectionNotice {
+        padding: var(--spacing-sm) var(--spacing-md);
+        font-size: 0.9rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- add an accent border, background and icon to the city selector group in the client request modal
- emphasize the city selection notice with contrasting colors and typography
- tune responsive spacing so the highlighted block works on desktop and mobile breakpoints

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc9d7158b483339deb02f61cd7b422