### PR TITLE
Уточнить обработку secure-параметров куков

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -59,7 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Определяем, выбрал ли пользователь "Запомнить меня"
         $remember = !empty($_POST['remember']);
 
-        $secure = !empty($_SERVER['HTTPS']);  // true, если используется HTTPS
+        $cookieSecurity = ff_get_cookie_security_options();  // включает secure/samesite с учётом HTTPS
 
         session_start();
 
@@ -92,8 +92,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $update->execute();
                 $update->close();
                 // Устанавливаем cookie с токеном и ID пользователя на 60 дней (Secure, HttpOnly)
-                setcookie('remember_token', $token, $tokenExpiry, "/", "", $secure, true);
-                setcookie('remember_user', (string)$user['id'], $tokenExpiry, "/", "", $secure, true);
+                $cookieOptions = array_merge([
+                    'expires' => $tokenExpiry,
+                    'path' => '/',
+                ], $cookieSecurity);
+                setcookie('remember_token', $token, $cookieOptions);
+                setcookie('remember_user', (string)$user['id'], $cookieOptions);
             }
         } else {
             // Если пользователь не хочет "запомнить", очищаем предыдущие токены

--- a/logout.php
+++ b/logout.php
@@ -12,13 +12,17 @@ if (!empty($_SESSION['user_id'])) {
     $stmt->close();
 }
 
-// Удаление cookie «Запомнить меня»
-$secure = !empty($_SERVER['HTTPS']);
-setcookie('remember_token', '', time() - 3600, "/", "", $secure, true);
-setcookie('remember_user', '', time() - 3600, "/", "", $secure, true);
+// Удаление cookie «Запомнить меня» и сессии
+$cookieSecurity = ff_get_cookie_security_options();
+$expiredOptions = array_merge([
+    'expires' => time() - 3600,
+    'path' => '/',
+], $cookieSecurity);
+setcookie('remember_token', '', $expiredOptions);
+setcookie('remember_user', '', $expiredOptions);
 
 // Удаление cookie сессии (чтобы браузер не хранил устаревший PHPSESSID)
-setcookie(session_name(), '', time() - 3600, "/", "", $secure, true);
+setcookie(session_name(), '', $expiredOptions);
 
 // Завершение сессии на сервере
 $_SESSION = [];

--- a/session_init.php
+++ b/session_init.php
@@ -1,3 +1,62 @@
 <?php
-session_set_cookie_params(['lifetime' => 60*24*60*60, 'path' => '/', 'secure' => !empty($_SERVER['HTTPS']), 'httponly' => true, 'samesite' => 'Lax']);
-ini_set('session.gc_maxlifetime', 60*24*60*60);
+
+if (!function_exists('ff_is_https_request')) {
+    function ff_is_https_request(): bool
+    {
+        if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {
+            return true;
+        }
+
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            $forwardedProto = strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']);
+            if (strpos($forwardedProto, ',') !== false) {
+                $forwardedProto = trim(explode(',', $forwardedProto)[0]);
+            }
+
+            if ($forwardedProto === 'https') {
+                return true;
+            }
+        }
+
+        if (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) === 'on') {
+            return true;
+        }
+
+        if (!empty($_SERVER['HTTP_FRONT_END_HTTPS']) && strtolower($_SERVER['HTTP_FRONT_END_HTTPS']) !== 'off') {
+            return true;
+        }
+
+        if (!empty($_SERVER['REQUEST_SCHEME']) && strtolower($_SERVER['REQUEST_SCHEME']) === 'https') {
+            return true;
+        }
+
+        if (!empty($_SERVER['SERVER_PORT']) && (int)$_SERVER['SERVER_PORT'] === 443) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+if (!function_exists('ff_get_cookie_security_options')) {
+    function ff_get_cookie_security_options(): array
+    {
+        $secure = ff_is_https_request();
+
+        return [
+            'secure' => $secure,
+            'httponly' => true,
+            'samesite' => $secure ? 'None' : 'Lax',
+        ];
+    }
+}
+
+$sessionLifetime = 60 * 24 * 60 * 60;
+$cookieSecurity = ff_get_cookie_security_options();
+
+session_set_cookie_params(array_merge([
+    'lifetime' => $sessionLifetime,
+    'path' => '/',
+], $cookieSecurity));
+
+ini_set('session.gc_maxlifetime', $sessionLifetime);


### PR DESCRIPTION
## Summary
- расширить определение HTTPS (учёт X-Forwarded-Proto/SSL, Front-End-Https, request_scheme, порта) и вынести генерацию общих cookie-опций
- использовать единые опции SameSite/Secure/HttpOnly при установке куков remember me и продлении PHPSESSID
- при выходе из аккаунта очищать куки с теми же параметрами, чтобы они гарантированно удалялись за прокси

## Testing
- php -l session_init.php
- php -l auth.php
- php -l auth_form.php
- php -l logout.php

------
https://chatgpt.com/codex/tasks/task_e_68ccad295f808333b166ed847ca67006