### PR TITLE
Обновить стили модального окна заявки

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -659,21 +659,50 @@ body.city-confirm-open {
 }
 
 .request-form__custom-fields {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+  align-items: stretch;
+}
+
+@media (max-width: 640px) {
+  .request-form__custom-fields {
+    grid-template-columns: 1fr;
+  }
 }
 
 .request-form__box-group {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  border: 1px solid var(--border, #e5e7eb);
-  border-radius: var(--radius, 8px);
-  background: var(--bg-secondary, #f9fafb);
-  transition: all 0.3s ease;
+  gap: 20px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: clamp(12px, 2vw, 16px);
+  background: var(--bg-primary, #ffffff);
+  box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.35);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
   position: relative;
+  height: 100%;
+}
+
+.request-form__box-group:hover {
+  transform: translateY(-2px);
+  border-color: rgba(40, 199, 111, 0.35);
+  box-shadow: 0 22px 40px -18px rgba(15, 23, 42, 0.45);
+}
+
+.request-form__box-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.request-form__box-group-hint {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-secondary, #6b7280);
+  line-height: 1.35;
 }
 
 .request-form__box-group-title {

--- a/form.js
+++ b/form.js
@@ -1041,7 +1041,9 @@ function generateBoxFields(count) {
 
         return `
       <div class="request-modal__box-group request-form__box-group box-group-item">
-        <strong class="request-modal__box-group-title request-form__box-group-title">Группа ${groupIndex + 1}:</strong>
+        <div class="request-modal__box-group-header request-form__box-group-header">
+          <strong class="request-modal__box-group-title request-form__box-group-title">Группа ${groupIndex + 1}:</strong>
+        </div>
         <div class="request-modal__box-group-inputs request-form__box-group-inputs">
 ${fieldsHtml}
         </div>


### PR DESCRIPTION
## Summary
- перевел блок пользовательских полей на адаптивную CSS-сетку и настроил отступы
- усилил карточный стиль групп коробов, добавив тени и hover-эффект
- выделил шапку группы отдельным контейнером для гибкого выравнивания контента

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccbdab5d68833390e06d688895f8a5