### PR TITLE
Remove scroll jump when collapsing schedule filters

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -178,9 +178,9 @@ class ScheduleManager {
         this.hasAppliedFilterCollapseState = true;
         this.updateFilterToggleButton();
 
-        if (shouldCollapse && scrollIntoView && this.scheduleResultsElement instanceof HTMLElement) {
-            this.scheduleResultsElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
+        // Ранее при сворачивании фильтра выполнялась прокрутка к результатам расписания.
+        // Это приводило к неожиданному изменению положения страницы, поэтому вызов
+        // scrollIntoView намеренно удалён.
     }
 
     updateFilterToggleButton() {


### PR DESCRIPTION
## Summary
- prevent automatic scrolling when the schedule filter panel is collapsed so the page position stays stable

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ccc14287f883338e93b4593ff7be13