### PR TITLE
Handle schedule filter collapse scroll behavior

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -166,7 +166,8 @@ class ScheduleManager {
 
     setFiltersCollapsed(collapsed, { scrollIntoView = false } = {}) {
         const shouldCollapse = Boolean(collapsed);
-        const hasStateChanged = this.isFiltersCollapsed !== shouldCollapse || !this.hasAppliedFilterCollapseState;
+        const wasStateApplied = this.hasAppliedFilterCollapseState;
+        const hasStateChanged = this.isFiltersCollapsed !== shouldCollapse || !wasStateApplied;
 
         this.isFiltersCollapsed = shouldCollapse;
 
@@ -175,12 +176,12 @@ class ScheduleManager {
             this.schedulePanelElement.classList.toggle('filters-expanded', !shouldCollapse);
         }
 
+        if (shouldCollapse && scrollIntoView && wasStateApplied && this.schedulePanelElement instanceof HTMLElement) {
+            this.schedulePanelElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+
         this.hasAppliedFilterCollapseState = true;
         this.updateFilterToggleButton();
-
-        // Ранее при сворачивании фильтра выполнялась прокрутка к результатам расписания.
-        // Это приводило к неожиданному изменению положения страницы, поэтому вызов
-        // scrollIntoView намеренно удалён.
     }
 
     updateFilterToggleButton() {


### PR DESCRIPTION
## Summary
- scroll the schedule panel into view when collapsing filters after the initial render
- prevent scroll on the first render and when expanding filters so the button keeps its behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccc88d243c83338a492f0070e41e89