### PR TITLE
feat: highlight city selection in request modal

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -1357,3 +1357,88 @@ body.city-confirm-open {
     padding: clamp(10px, 5.5vw, 13px) clamp(12px, 6.5vw, 14px);
   }
 }
+/* Акцентное оформление выбора города */
+.request-form__city-group {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: clamp(20px, 4vw, 26px) clamp(20px, 5vw, 30px);
+    border: 1.5px solid rgba(5, 150, 105, 0.4);
+    border-radius: clamp(16px, 4vw, 20px);
+    background: linear-gradient(135deg, rgba(5, 150, 105, 0.12), rgba(5, 150, 105, 0.04));
+    box-shadow: 0 18px 28px -22px rgba(5, 150, 105, 0.6);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.request-form__city-group:focus-within {
+    border-color: var(--primary, #059669);
+    box-shadow: 0 0 0 4px rgba(5, 150, 105, 0.18);
+    background: linear-gradient(135deg, rgba(5, 150, 105, 0.18), rgba(5, 150, 105, 0.06));
+}
+
+.request-form__city-control {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.request-form__city-select {
+    width: 100%;
+    min-width: 0;
+    padding: 14px 16px;
+    border: 2px solid rgba(5, 150, 105, 0.45);
+    border-radius: 14px;
+    font-weight: 600;
+    background: rgba(5, 150, 105, 0.1);
+    box-shadow: inset 0 1px 2px rgba(17, 24, 39, 0.08);
+    transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.request-form__city-select:hover {
+    border-color: var(--primary, #059669);
+}
+
+.request-form__city-select:focus {
+    background: var(--bg-white, #ffffff);
+    border-color: var(--primary, #059669);
+    box-shadow: 0 0 0 4px rgba(5, 150, 105, 0.18);
+    outline: none;
+}
+
+#citySelectionNotice {
+    margin: -8px 0 28px;
+    padding: 16px clamp(24px, 6vw, 32px);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    border-radius: clamp(16px, 4vw, 20px);
+    border: 1px solid rgba(5, 150, 105, 0.35);
+    background: linear-gradient(135deg, rgba(5, 150, 105, 0.12), rgba(5, 150, 105, 0.02));
+    color: var(--primary, #059669);
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+#citySelectionNotice::before {
+    content: "ℹ";
+    font-size: 1.125rem;
+    line-height: 1;
+}
+
+@media (min-width: 768px) {
+    .request-form__city-group {
+        flex-direction: row;
+        align-items: center;
+        gap: clamp(18px, 3vw, 28px);
+        padding: clamp(22px, 3vw, 28px) clamp(32px, 6vw, 40px);
+    }
+
+    .request-form__city-control {
+        flex: 1 1 auto;
+    }
+
+    #citySelectionNotice {
+        margin: -8px 0 32px clamp(32px, 6vw, 40px);
+    }
+}


### PR DESCRIPTION
## Summary
- добавлен акцентный стиль для блока выбора города в клиентском модальном окне
- обновлено уведомление о выборе города в соответствии с дизайном и добавлены реакции наведения/фокуса
- настроены десктопные отступы через медиазапрос для корректного вида на широкой ширине

## Testing
- npm run build *(падает: Could not resolve entry module "index.html")*
- ручная проверка выделения выбора города в модалке на ширине ≥ 768px


------
https://chatgpt.com/codex/tasks/task_e_68ccd5749a408333b54b3d1e7e345eaa