### PR TITLE
Добавить фильтр маркетплейсов в клиентском разделе тарифов

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -183,6 +183,14 @@ if (empty($_SESSION['user_id'])) {
             </div>
 
             <div class="tariffs-container">
+                <div class="tariffs-filters">
+                    <div class="tariffs-filter-control">
+                        <label class="tariffs-filter-label" for="tariffsMarketplaceFilter">Маркетплейс</label>
+                        <select id="tariffsMarketplaceFilter" class="tariffs-filter-select" aria-label="Фильтр по маркетплейсу">
+                            <option value="all">Загрузка...</option>
+                        </select>
+                    </div>
+                </div>
                 <div class="city-tabs" id="cityTabs">
                     <!-- Табы городов генерируются динамически -->
                 </div>

--- a/client/js/tariffs.js
+++ b/client/js/tariffs.js
@@ -1,115 +1,367 @@
 // Управление тарифами
 class TariffsManager {
     constructor() {
+        this.ALL_MARKETPLACE = 'all';
+        this.UNASSIGNED_MARKETPLACE = '__unassigned';
+
         this.tariffs = {};
+        this.marketplaceTariffs = {};
+        this.marketplaceOptions = [];
+        this.currentMarketplace = this.ALL_MARKETPLACE;
         this.currentCity = '';
+        this.hasLoaded = false;
+        this.isLoading = false;
+
+        this.elements = {
+            cityTabs: document.getElementById('cityTabs'),
+            tableContainer: document.getElementById('tariffsTable'),
+            marketplaceSelect: document.getElementById('tariffsMarketplaceFilter')
+        };
+
         this.init();
     }
 
     init() {
+        this.setupEventListeners();
         this.loadTariffs();
     }
 
-    async loadTariffs(city, warehouse) {
-        try {
-            // Определяем, какой эндпоинт использовать
-            const url = (city && warehouse)
-                ? `../get_tariff.php?city=${encodeURIComponent(city)}&warehouse=${encodeURIComponent(warehouse)}`
-                : '../tariffs/fetch_tariffs.php';
-
-            const response = await fetch(url);
-            const data = await response.json();
-
-            if (!data.success) {
-                throw new Error(data.message || 'Сервер вернул ошибку');
-            }
-
-            // Формируем структуру тарифов
-            if (city && warehouse) {
-                this.tariffs = {
-                    [city]: {
-                        [warehouse]: {
-                            box: data.base_price,
-                            pallet: data.pallet_price
-                        }
-                    }
-                };
-            } else {
-                const tariffs = {};
-                for (const [cityName, warehouses] of Object.entries(data.data)) {
-                    tariffs[cityName] = {};
-                    for (const [whName, prices] of Object.entries(warehouses)) {
-                        tariffs[cityName][whName] = {
-                            box: prices.box_price,
-                            pallet: prices.pallet_price
-                        };
-                    }
-                }
-                this.tariffs = tariffs;
-            }
-
-            // Отрисовываем таблицу тарифов
-            this.renderTariffs();
-        } catch (error) {
-            console.error('Ошибка загрузки тарифов:', error);
-            if (window.app && typeof window.app.showError === 'function') {
-                window.app.showError('Не удалось загрузить тарифы');
-            }
-        }
-    }
-
-    renderTariffs() {
-        this.renderCityTabs();
-        
-        const cities = Object.keys(this.tariffs);
-        if (cities.length > 0) {
-            this.currentCity = cities[0];
-            this.renderTariffsTable(this.currentCity);
-        }
-    }
-
-    renderCityTabs() {
-        const cityTabs = document.getElementById('cityTabs');
-        if (!cityTabs) return;
-
-        const cities = Object.keys(this.tariffs);
-        
-        cityTabs.innerHTML = cities.map((city, index) => `
-            <button class="city-tab ${index === 0 ? 'active' : ''}" data-city="${city}">
-                ${city}
-            </button>
-        `).join('');
-
-        // Добавляем обработчики
-        cityTabs.querySelectorAll('.city-tab').forEach(tab => {
-            tab.addEventListener('click', () => {
-                const city = tab.dataset.city;
-                this.switchCity(city);
-                
-                cityTabs.querySelectorAll('.city-tab').forEach(t => t.classList.remove('active'));
-                tab.classList.add('active');
+    setupEventListeners() {
+        const { marketplaceSelect } = this.elements;
+        if (marketplaceSelect) {
+            marketplaceSelect.addEventListener('change', (event) => {
+                this.handleMarketplaceChange(event.target.value);
             });
-        });
+        }
     }
 
-    switchCity(city) {
-        this.currentCity = city;
-        this.renderTariffsTable(city);
-    }
+    async loadTariffs(optionsOrCity, warehouse) {
+        if (typeof optionsOrCity === 'string' && typeof warehouse === 'string') {
+            return this.fetchSingleTariff(optionsOrCity, warehouse);
+        }
 
-    renderTariffsTable(city) {
-        const container = document.getElementById('tariffsTable');
-        if (!container) return;
-
-        const cityTariffs = this.tariffs[city];
-        if (!cityTariffs) {
-            container.innerHTML = '<p class="text-center text-muted">Нет данных по тарифам для выбранного города</p>';
+        if (this.isLoading) {
             return;
         }
 
+        const isOptionsObject = typeof optionsOrCity === 'object' && optionsOrCity !== null;
+        const forceReload = optionsOrCity === true || (isOptionsObject && optionsOrCity.force === true);
+
+        if (this.hasLoaded && !forceReload) {
+            this.renderTariffs();
+            return;
+        }
+
+        this.isLoading = true;
+
+        const previousMarketplace = this.currentMarketplace;
+        const previousCity = this.currentCity;
+
+        if (!this.hasLoaded) {
+            this.showLoadingState();
+        }
+
+        try {
+            const response = await fetch('../tariffs/fetch_tariffs.php');
+            const result = await response.json();
+
+            if (!result.success) {
+                throw new Error(result.message || 'Сервер вернул ошибку');
+            }
+
+            this.processTariffsData(result.data || {});
+
+            const hasMarketplace = this.marketplaceOptions.some(option => option.value === previousMarketplace);
+            this.currentMarketplace = hasMarketplace ? previousMarketplace : this.ALL_MARKETPLACE;
+
+            const filteredTariffs = this.getTariffsByMarketplace(this.currentMarketplace);
+            this.currentCity = previousCity && filteredTariffs[previousCity] ? previousCity : '';
+
+            this.renderTariffs();
+            this.hasLoaded = true;
+        } catch (error) {
+            console.error('Ошибка загрузки тарифов:', error);
+            if (!this.hasLoaded) {
+                this.showErrorState(error?.message);
+            }
+            if (window.app?.showError) {
+                window.app.showError('Не удалось загрузить тарифы');
+            }
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    async fetchSingleTariff(city, warehouse) {
+        const url = `../get_tariff.php?city=${encodeURIComponent(city)}&warehouse=${encodeURIComponent(warehouse)}`;
+
+        try {
+            const response = await fetch(url);
+            const result = await response.json();
+
+            if (!result.success) {
+                throw new Error(result.message || 'Тариф не найден');
+            }
+
+            const tariff = {
+                box: this.toNumber(result.base_price),
+                pallet: this.toNumber(result.pallet_price),
+                boxCoef: this.toNumber(result.box_coef),
+                perLiter: this.toNumber(result.per_liter)
+            };
+
+            const existing = this.tariffs[city]?.[warehouse];
+            if (existing) {
+                existing.box = tariff.box;
+                existing.pallet = tariff.pallet;
+            }
+
+            return tariff;
+        } catch (error) {
+            console.error('Ошибка получения тарифа:', error);
+            throw error;
+        }
+    }
+
+    processTariffsData(rawData) {
+        const normalizedTariffs = {};
+        const groupedByMarketplace = {};
+        const marketplaceOrder = [];
+        const seenMarketplaces = new Set();
+        let hasUnassigned = false;
+
+        for (const [cityName, warehouses] of Object.entries(rawData)) {
+            if (!normalizedTariffs[cityName]) {
+                normalizedTariffs[cityName] = {};
+            }
+
+            for (const [warehouseName, values] of Object.entries(warehouses || {})) {
+                const marketplaceName = this.normalizeMarketplace(values.marketplace);
+                const entry = {
+                    box: this.toNumber(values.box_price),
+                    pallet: this.toNumber(values.pallet_price),
+                    marketplace: marketplaceName,
+                    marketplaceId: values.marketplace_id ?? null
+                };
+
+                normalizedTariffs[cityName][warehouseName] = entry;
+
+                const marketplaceKey = marketplaceName || this.UNASSIGNED_MARKETPLACE;
+
+                if (!groupedByMarketplace[marketplaceKey]) {
+                    groupedByMarketplace[marketplaceKey] = {};
+                }
+
+                if (!groupedByMarketplace[marketplaceKey][cityName]) {
+                    groupedByMarketplace[marketplaceKey][cityName] = {};
+                }
+
+                groupedByMarketplace[marketplaceKey][cityName][warehouseName] = entry;
+
+                if (marketplaceName) {
+                    if (!seenMarketplaces.has(marketplaceName)) {
+                        seenMarketplaces.add(marketplaceName);
+                        marketplaceOrder.push(marketplaceName);
+                    }
+                } else {
+                    hasUnassigned = true;
+                }
+            }
+        }
+
+        const options = [{ value: this.ALL_MARKETPLACE, label: 'Все маркетплейсы' }];
+
+        marketplaceOrder.forEach(name => {
+            options.push({ value: name, label: name });
+        });
+
+        if (hasUnassigned) {
+            options.push({ value: this.UNASSIGNED_MARKETPLACE, label: 'Без маркетплейса' });
+        }
+
+        this.tariffs = normalizedTariffs;
+        this.marketplaceTariffs = groupedByMarketplace;
+        this.marketplaceOptions = options;
+    }
+
+    getTariffsByMarketplace(marketplaceKey) {
+        if (marketplaceKey === this.ALL_MARKETPLACE) {
+            return this.tariffs;
+        }
+
+        return this.marketplaceTariffs[marketplaceKey] || {};
+    }
+
+    renderTariffs() {
+        const hasTariffs = Object.keys(this.tariffs).length > 0;
+        this.renderMarketplaceFilter(hasTariffs);
+
+        const filteredTariffs = this.getTariffsByMarketplace(this.currentMarketplace);
+        const cities = Object.keys(filteredTariffs);
+
+        if (!cities.length) {
+            this.currentCity = '';
+            this.renderCityTabs(filteredTariffs, cities);
+            this.renderTariffsTable(filteredTariffs, '');
+            return;
+        }
+
+        if (!this.currentCity || !filteredTariffs[this.currentCity]) {
+            this.currentCity = cities[0];
+        }
+
+        this.renderCityTabs(filteredTariffs, cities);
+        this.renderTariffsTable(filteredTariffs, this.currentCity);
+    }
+
+    renderMarketplaceFilter(hasTariffs) {
+        const { marketplaceSelect } = this.elements;
+        if (!marketplaceSelect) {
+            return;
+        }
+
+        if (!hasTariffs) {
+            marketplaceSelect.innerHTML = '<option value="">Нет тарифов</option>';
+            marketplaceSelect.value = '';
+            marketplaceSelect.disabled = true;
+            return;
+        }
+
+        marketplaceSelect.disabled = false;
+        marketplaceSelect.innerHTML = this.marketplaceOptions
+            .map(option => `<option value="${option.value}">${option.label}</option>`)
+            .join('');
+
+        const selectedOption = this.marketplaceOptions.find(option => option.value === this.currentMarketplace);
+        const selectedValue = selectedOption ? selectedOption.value : this.ALL_MARKETPLACE;
+
+        this.currentMarketplace = selectedValue;
+        marketplaceSelect.value = selectedValue;
+    }
+
+    handleMarketplaceChange(value) {
+        const newValue = value || this.ALL_MARKETPLACE;
+        if (newValue === this.currentMarketplace) {
+            return;
+        }
+
+        this.currentMarketplace = newValue;
+        this.renderTariffs();
+    }
+
+    renderCityTabs(filteredTariffs, cities) {
+        const { cityTabs } = this.elements;
+        if (!cityTabs) {
+            return;
+        }
+
+        cityTabs.innerHTML = '';
+        cityTabs.classList.toggle('is-hidden', cities.length === 0);
+
+        if (!cities.length) {
+            return;
+        }
+
+        const fragment = document.createDocumentFragment();
+
+        cities.forEach(city => {
+            const tab = document.createElement('button');
+            tab.type = 'button';
+            tab.className = `city-tab${city === this.currentCity ? ' active' : ''}`;
+            tab.dataset.city = city;
+            tab.textContent = city;
+
+            tab.addEventListener('click', () => {
+                if (this.currentCity === city) {
+                    return;
+                }
+                this.currentCity = city;
+                this.renderTariffs();
+            });
+
+            fragment.appendChild(tab);
+        });
+
+        cityTabs.appendChild(fragment);
+    }
+
+    renderTariffsTable(filteredTariffs, city) {
+        const { tableContainer } = this.elements;
+        if (!tableContainer) {
+            return;
+        }
+
+        tableContainer.classList.remove('is-empty');
+        tableContainer.innerHTML = '';
+
+        if (!Object.keys(this.tariffs).length) {
+            tableContainer.classList.add('is-empty');
+            tableContainer.innerHTML = this.createEmptyState({
+                icon: 'truck-ramp-box',
+                title: 'Нет доступных тарифов',
+                description: 'Сейчас в системе нет тарифов. Попробуйте обновить страницу позже.'
+            });
+            return;
+        }
+
+        if (!city) {
+            tableContainer.classList.add('is-empty');
+            tableContainer.innerHTML = this.createEmptyState({
+                icon: 'circle-info',
+                title: 'Нет данных',
+                description: 'Для выбранного маркетплейса нет городов с тарифами.'
+            });
+            return;
+        }
+
+        const cityTariffs = filteredTariffs[city] || {};
         const warehouses = Object.keys(cityTariffs);
-        
-        container.innerHTML = `
+
+        if (!warehouses.length) {
+            tableContainer.classList.add('is-empty');
+            tableContainer.innerHTML = this.createEmptyState({
+                icon: 'city',
+                title: 'Нет тарифов по выбранному городу',
+                description: 'Выберите другой город или маркетплейс, чтобы увидеть доступные склады.'
+            });
+            return;
+        }
+
+        const rows = warehouses.map(warehouse => {
+            const tariff = cityTariffs[warehouse];
+            const boxPrice = this.formatPrice(tariff.box);
+            const palletPrice = this.formatPrice(tariff.pallet);
+            const cubicVolume = (60 * 40 * 40) / 1_000_000;
+            const cubicPrice = typeof tariff.box === 'number' && tariff.box > 0
+                ? `≈${this.formatPrice(Math.round(tariff.box / cubicVolume))}`
+                : '—';
+            const cubicNote = typeof tariff.box === 'number' && tariff.box > 0
+                ? '<div class="price-note text-muted">за м³</div>'
+                : '<div class="price-note text-muted">нет данных</div>';
+
+            return `
+                <tr>
+                    <td>
+                        <div class="warehouse-name">${warehouse}</div>
+                        <div class="warehouse-location text-muted">Московская область</div>
+                    </td>
+                    <td>
+                        <span class="price-value">${boxPrice}</span>
+                        <div class="price-note text-muted">за стандартную коробку</div>
+                    </td>
+                    <td>
+                        <span class="price-value">${palletPrice}</span>
+                        <div class="price-note text-muted">за паллету</div>
+                    </td>
+                    <td>
+                        <span class="price-value">${cubicPrice}</span>
+                        ${cubicNote}
+                    </td>
+                </tr>
+            `;
+        }).join('');
+
+        tableContainer.innerHTML = `
             <table class="tariffs-table">
                 <thead>
                     <tr>
@@ -120,35 +372,17 @@ class TariffsManager {
                     </tr>
                 </thead>
                 <tbody>
-                    ${warehouses.map(warehouse => {
-                        const tariff = cityTariffs[warehouse];
-                        const boxVolume = (60 * 40 * 40) / 1000000; // м³
-                        const pricePerCubicMeter = Math.round(tariff.box / boxVolume);
-                        
-                        return `
-                            <tr>
-                                <td>
-                                    <div class="warehouse-name">${warehouse}</div>
-                                    <div class="warehouse-location text-muted">Московская область</div>
-                                </td>
-                                <td>
-                                    <span class="price-value">${window.utils.formatCurrency(tariff.box)}</span>
-                                    <div class="price-note text-muted">за стандартную коробку</div>
-                                </td>
-                                <td>
-                                    <span class="price-value">${window.utils.formatCurrency(tariff.pallet)}</span>
-                                    <div class="price-note text-muted">за паллету</div>
-                                </td>
-                                <td>
-                                    <span class="price-value">≈${window.utils.formatCurrency(pricePerCubicMeter)}</span>
-                                    <div class="price-note text-muted">за м³</div>
-                                </td>
-                            </tr>
-                        `;
-                    }).join('')}
+                    ${rows}
                 </tbody>
             </table>
-            
+            ${this.buildTariffsNote()}
+        `;
+
+        this.ensureTableStyles();
+    }
+
+    buildTariffsNote() {
+        return `
             <div class="tariffs-note">
                 <h4>Дополнительная информация</h4>
                 <ul>
@@ -160,72 +394,183 @@ class TariffsManager {
                 </ul>
             </div>
         `;
+    }
 
-        // Добавляем стили
-        if (!document.getElementById('tariffsTableStyles')) {
-            const styles = document.createElement('style');
-            styles.id = 'tariffsTableStyles';
-            styles.textContent = `
-                .warehouse-name {
-                    font-weight: 600;
-                    color: var(--text-primary);
-                }
-                .warehouse-location {
-                    font-size: 0.8rem;
-                    margin-top: 2px;
-                }
-                .price-note {
-                    font-size: 0.8rem;
-                    margin-top: 2px;
-                }
-                .tariffs-note {
-                    margin-top: 24px;
-                    padding: 20px;
-                    background: var(--bg-secondary);
-                    border-radius: var(--radius);
-                }
-                .tariffs-note h4 {
-                    font-size: 1rem;
-                    font-weight: 600;
-                    margin-bottom: 12px;
-                    color: var(--text-primary);
-                }
-                .tariffs-note ul {
-                    list-style: none;
-                    padding: 0;
-                    margin: 0;
-                }
-                .tariffs-note li {
-                    padding: 6px 0;
-                    color: var(--text-secondary);
-                    font-size: 0.9rem;
-                    position: relative;
-                    padding-left: 20px;
-                }
-                .tariffs-note li::before {
-                    content: "•";
-                    color: var(--primary);
-                    position: absolute;
-                    left: 0;
-                    font-weight: bold;
-                }
-            `;
-            document.head.appendChild(styles);
+    ensureTableStyles() {
+        if (document.getElementById('tariffsTableStyles')) {
+            return;
+        }
+
+        const styles = document.createElement('style');
+        styles.id = 'tariffsTableStyles';
+        styles.textContent = `
+            .warehouse-name {
+                font-weight: 600;
+                color: var(--text-primary);
+            }
+            .warehouse-location {
+                font-size: 0.8rem;
+                margin-top: 2px;
+            }
+            .price-note {
+                font-size: 0.8rem;
+                margin-top: 2px;
+            }
+            .tariffs-note {
+                margin-top: 24px;
+                padding: 20px;
+                background: var(--bg-secondary);
+                border-radius: var(--radius);
+            }
+            .tariffs-note h4 {
+                font-size: 1rem;
+                font-weight: 600;
+                margin-bottom: 12px;
+                color: var(--text-primary);
+            }
+            .tariffs-note ul {
+                list-style: none;
+                padding: 0;
+                margin: 0;
+            }
+            .tariffs-note li {
+                padding: 6px 0;
+                color: var(--text-secondary);
+                font-size: 0.9rem;
+                position: relative;
+                padding-left: 20px;
+            }
+            .tariffs-note li::before {
+                content: "•";
+                color: var(--primary);
+                position: absolute;
+                left: 0;
+                font-weight: bold;
+            }
+        `;
+        document.head.appendChild(styles);
+    }
+
+    createEmptyState({ icon = 'circle-info', iconClass = '', title = '', description = '' } = {}) {
+        const iconHtml = icon
+            ? `<div class="tariffs-empty-icon"><i class="fas fa-${icon} ${iconClass}"></i></div>`
+            : '';
+        const titleHtml = title ? `<div class="tariffs-empty-title">${title}</div>` : '';
+        const descriptionHtml = description
+            ? `<p class="tariffs-empty-description">${description}</p>`
+            : '';
+
+        return `
+            <div class="tariffs-empty">
+                ${iconHtml}
+                ${titleHtml}
+                ${descriptionHtml}
+            </div>
+        `;
+    }
+
+    showLoadingState() {
+        const { tableContainer, cityTabs, marketplaceSelect } = this.elements;
+        if (tableContainer) {
+            tableContainer.classList.add('is-empty');
+            tableContainer.innerHTML = this.createEmptyState({
+                icon: 'spinner',
+                iconClass: 'fa-spin',
+                title: 'Загрузка тарифов',
+                description: 'Пожалуйста, подождите — мы подготавливаем данные.'
+            });
+        }
+
+        if (marketplaceSelect) {
+            marketplaceSelect.disabled = true;
+            marketplaceSelect.innerHTML = '<option value="all">Загрузка...</option>';
+        }
+
+        if (cityTabs) {
+            cityTabs.classList.add('is-hidden');
+            cityTabs.innerHTML = '';
         }
     }
 
-    getTariff(city, warehouse, type = 'box') {
-        if (!this.tariffs[city] || !this.tariffs[city][warehouse]) {
+    showErrorState(message) {
+        const { tableContainer, cityTabs, marketplaceSelect } = this.elements;
+        if (tableContainer) {
+            tableContainer.classList.add('is-empty');
+            tableContainer.innerHTML = this.createEmptyState({
+                icon: 'triangle-exclamation',
+                title: 'Не удалось загрузить тарифы',
+                description: message || 'Попробуйте повторить попытку немного позже.'
+            });
+        }
+
+        if (marketplaceSelect) {
+            marketplaceSelect.innerHTML = '<option value="">Недоступно</option>';
+            marketplaceSelect.value = '';
+            marketplaceSelect.disabled = true;
+        }
+
+        if (cityTabs) {
+            cityTabs.classList.add('is-hidden');
+            cityTabs.innerHTML = '';
+        }
+    }
+
+    formatPrice(value) {
+        if (typeof value !== 'number' || Number.isNaN(value)) {
+            return '—';
+        }
+
+        if (window.utils?.formatCurrency) {
+            return window.utils.formatCurrency(value);
+        }
+
+        return `${value.toLocaleString('ru-RU')} ₽`;
+    }
+
+    toNumber(value) {
+        if (value === null || value === undefined || value === '') {
             return null;
         }
-        return this.tariffs[city][warehouse][type];
+
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    normalizeMarketplace(value) {
+        if (typeof value !== 'string') {
+            return null;
+        }
+
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+    }
+
+    getTariff(city, warehouse, type = 'box') {
+        const cityTariffs = this.tariffs[city];
+        if (!cityTariffs) {
+            return null;
+        }
+
+        const warehouseTariff = cityTariffs[warehouse];
+        if (!warehouseTariff) {
+            return null;
+        }
+
+        return warehouseTariff[type] ?? null;
     }
 
     calculateShippingCost(city, warehouse, quantity, type = 'box') {
         const unitPrice = this.getTariff(city, warehouse, type);
-        if (!unitPrice) return null;
-        
-        return unitPrice * quantity;
+        if (unitPrice === null || unitPrice === undefined) {
+            return null;
+        }
+
+        const normalizedQuantity = Number(quantity);
+        if (!Number.isFinite(normalizedQuantity)) {
+            return null;
+        }
+
+        return unitPrice * normalizedQuantity;
     }
 }
 

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -1366,6 +1366,129 @@ body {
 }
 
 /* Tariffs */
+.tariffs-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-end;
+    padding: 24px;
+    background: white;
+    border-bottom: 1px solid var(--border-light);
+}
+
+.tariffs-filter-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.tariffs-filter-control {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 220px;
+}
+
+.tariffs-filter-select {
+    min-width: 220px;
+    padding: 12px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: white;
+    color: var(--text-primary);
+    font-weight: 500;
+    transition: var(--transition);
+    cursor: pointer;
+    appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),
+        linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%);
+    background-position: calc(100% - 20px) calc(50% - 4px), calc(100% - 15px) calc(50% - 4px);
+    background-size: 5px 5px, 5px 5px;
+    background-repeat: no-repeat;
+    padding-right: 40px;
+}
+
+.tariffs-filter-select:focus-visible {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 4px rgba(40, 199, 111, 0.12);
+}
+
+.tariffs-filter-select:disabled {
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    cursor: not-allowed;
+    border-color: var(--border-light);
+}
+
+.tariffs-empty {
+    padding: 48px 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 12px;
+    color: var(--text-secondary);
+}
+
+.tariffs-empty-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--bg-secondary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--primary);
+    font-size: 1.4rem;
+}
+
+.tariffs-empty-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.tariffs-empty-description {
+    max-width: 420px;
+    line-height: 1.5;
+}
+
+.city-tabs.is-hidden {
+    display: none;
+}
+
+.tariffs-table-container.is-empty {
+    padding: 40px 24px;
+}
+
+.tariffs-table-container.is-empty .tariffs-empty {
+    padding: 0;
+}
+
+@media (max-width: 768px) {
+    .tariffs-filters {
+        padding: 20px;
+        gap: 12px;
+    }
+
+    .tariffs-filter-control {
+        min-width: 100%;
+        width: 100%;
+    }
+
+    .tariffs-filter-select {
+        min-width: 100%;
+        width: 100%;
+    }
+
+    .tariffs-table-container.is-empty {
+        padding: 32px 20px;
+    }
+}
+
 .tariffs-container {
     background: white;
     border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- добавить фильтр маркетплейсов над блоком тарифов клиента и оформить его в стиле интерфейса
- переработать клиентский менеджер тарифов: группировка по маркетплейсам/городам, обработка пустых данных и сохранение состояния
- сохранить доступ к полному набору тарифов и улучшить сценарии загрузки/ошибок

## Testing
- php -l client/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cce6788d8c8333ad2c82e34af8d2e6