### PR TITLE
feat: highlight notification button

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -126,23 +126,25 @@ body {
 .notification-btn {
     position: relative;
     padding: 12px;
-    border: none;
-    background: transparent;
-    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    background: var(--bg-tertiary);
+    color: var(--primary);
     border-radius: var(--radius);
     cursor: pointer;
     transition: var(--transition);
+    box-shadow: var(--shadow-sm);
 }
 
 .notification-btn:hover {
-    background: var(--bg-tertiary);
-    color: var(--text-primary);
+    background: #e5e7eb;
+    color: var(--primary);
+    border-color: #d1d5db;
 }
 
 .notification-badge {
     position: absolute;
-    top: 8px;
-    right: 8px;
+    top: 6px;
+    right: 6px;
     background: var(--error);
     color: white;
     font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- add a subtle background, border, and icon color to the notification button for better contrast
- tweak hover state to keep the button readable when active
- shift the notification badge inward to avoid overlapping the refreshed button styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccf0a85a4c8333b4d04d71106f72c2