### PR TITLE
Prevent step index from shrinking in flex layouts

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -762,6 +762,7 @@ body {
     font-weight: 700;
     font-size: 0.95rem;
     transition: var(--transition);
+    flex-shrink: 0;
 }
 
 .schedule-step.is-active .step-index {


### PR DESCRIPTION
## Summary
- prevent schedule step index indicator from shrinking inside flex containers by disabling flex shrink

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ccf51f8b4c8333890549b89fd98cee