### PR TITLE
Prevent repeated confirmation clicks in city modal

### DIFF
--- a/client/styles/request-modal.css
+++ b/client/styles/request-modal.css
@@ -138,6 +138,28 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
+.city-confirm-button[disabled],
+.city-confirm-button--disabled {
+    background: var(--bg-secondary, #f3f4f6);
+    border-color: var(--border, #d1d5db);
+    color: var(--text-disabled, #9ca3af);
+    box-shadow: none;
+    transform: none;
+    cursor: default;
+    pointer-events: none;
+}
+
+.city-confirm-button[disabled]:hover,
+.city-confirm-button--disabled:hover,
+.city-confirm-button[disabled]:focus-visible,
+.city-confirm-button--disabled:focus-visible {
+    box-shadow: none;
+    transform: none;
+    background: var(--bg-secondary, #f3f4f6);
+    border-color: var(--border, #d1d5db);
+    color: var(--text-disabled, #9ca3af);
+}
+
 .city-confirm-button:focus-visible {
     outline: none;
     box-shadow: 0 0 0 4px rgba(40, 199, 111, 0.25);

--- a/form.js
+++ b/form.js
@@ -256,7 +256,38 @@ function openCityConfirmationModal({ cityName = '', cityElement = null } = {}) {
         const editBtn = overlay.querySelector('[data-role="edit"]');
         const closeBtn = overlay.querySelector('[data-role="close"]');
 
-        confirmBtn?.addEventListener('click', () => finish(true));
+        if (confirmBtn) {
+            const disableConfirmButton = () => {
+                if (!confirmBtn.disabled) {
+                    confirmBtn.disabled = true;
+                }
+                if (confirmBtn.getAttribute('aria-disabled') !== 'true') {
+                    confirmBtn.setAttribute('aria-disabled', 'true');
+                }
+                confirmBtn.classList.add('city-confirm-button--disabled');
+            };
+
+            const isConfirmButtonDisabled = () => (
+                confirmBtn.disabled
+                || confirmBtn.getAttribute('aria-disabled') === 'true'
+                || confirmBtn.classList.contains('city-confirm-button--disabled')
+            );
+
+            confirmBtn.addEventListener('click', (event) => {
+                if (isConfirmButtonDisabled()) {
+                    event.preventDefault();
+                    if (typeof event.stopImmediatePropagation === 'function') {
+                        event.stopImmediatePropagation();
+                    } else {
+                        event.stopPropagation();
+                    }
+                    return;
+                }
+
+                disableConfirmButton();
+                finish(true);
+            });
+        }
         editBtn?.addEventListener('click', closeAndFocusCity);
         closeBtn?.addEventListener('click', closeAndFocusCity);
 


### PR DESCRIPTION
## Summary
- disable the city confirmation action button after the first activation to avoid repeated handling
- add visual styling for the disabled confirmation button in the modal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccf6ff8c0883338fc307851ac72ab7