### PR TITLE
Привести расписание клиента к новому шаблону

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -82,95 +82,27 @@ if (empty($_SESSION['user_id'])) {
             </div>
 
             <div class="schedule-panel" id="schedulePanel">
-                <div class="schedule-filters" id="scheduleFilters">
-                    <div class="schedule-steps" id="scheduleSteps">
-                        <div class="schedule-step is-active" data-step="marketplace">
-                            <div class="step-header">
-                                <div class="step-title">
-                                    <span class="step-index">1</span>
-                                    <div class="step-text">
-                                        <h3>Выберите маркетплейс</h3>
-                                        <p>Укажите площадку, для которой хотите оформить отправление</p>
-                                    </div>
-                                </div>
-                                <button type="button" class="step-change-btn" id="changeMarketplaceBtn">Изменить</button>
-                            </div>
-                            <div class="step-body">
-                                <div class="schedule-filter">
-                                    <label id="marketplaceFilterLabel">Маркетплейс</label>
-                                    <div
-                                        id="marketplaceFilter"
-                                        class="marketplace-grid"
-                                        role="group"
-                                        aria-labelledby="marketplaceFilterLabel"
-                                    >
-                                        <div class="marketplace-placeholder marketplace-placeholder--loading">
-                                            <span>Загрузка маркетплейсов...</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="step-actions">
-                                    <button type="button" class="step-next-btn" id="confirmMarketplace" disabled>Далее</button>
-                                </div>
-                            </div>
-                            <div class="step-summary" id="marketplaceSummary"></div>
-                        </div>
-
-                        <div class="schedule-step" data-step="warehouse">
-                            <div class="step-header">
-                                <div class="step-title">
-                                    <span class="step-index">2</span>
-                                    <div class="step-text">
-                                        <h3>Выберите склад</h3>
-                                        <p>Доступные склады покажутся после подтверждения маркетплейса</p>
-                                    </div>
-                                </div>
-                                <button type="button" class="step-change-btn" id="changeWarehouseBtn">Изменить</button>
-                            </div>
-                            <div class="step-body">
-                                <div class="schedule-filter">
-                                    <label for="warehouseFilter">Склад</label>
-                                    <select id="warehouseFilter" class="filter-select" disabled>
-                                        <option value="">Сначала выберите маркетплейс</option>
-                                    </select>
-                                </div>
-                                <div
-                                    id="warehouseStats"
-                                    class="warehouse-stats"
-                                    aria-live="polite"
-                                    aria-atomic="true"
-                                    aria-hidden="true"
-                                ></div>
-                                <div class="step-actions">
-                                    <button type="button" class="step-prev-btn" id="backToMarketplaceBtn">Назад</button>
-                                    <button type="button" class="step-next-btn" id="confirmWarehouse" disabled>Показать расписание</button>
-                                </div>
-                            </div>
-                            <div class="step-summary" id="warehouseSummary"></div>
+                <div class="schedule-wrap">
+                    <div class="schedule-filters">
+                        <select id="marketplace" class="schedule-select" aria-label="Выбор маркетплейса">
+                            <option value="">Все маркетплейсы</option>
+                        </select>
+                        <div class="schedule-origin-tabs" id="originTabs" role="tablist" aria-label="Города отправления">
+                            <!-- Табы городов генерируются динамически -->
                         </div>
                     </div>
 
-                    <button class="reset-filters-btn" id="resetScheduleFilters">
-                        <i class="fas fa-rotate-right"></i>
-                        Сбросить фильтры
-                    </button>
-                </div>
-
-                <div class="schedule-results">
-                    <div class="schedule-results-header">
-                        <p class="schedule-info" id="scheduleSubtitle">Чтобы увидеть расписание, выберите маркетплейс и склад</p>
-                        <button
-                            type="button"
-                            class="filter-toggle-btn"
-                            id="filterToggleBtn"
-                            aria-expanded="true"
-                            aria-controls="scheduleFilters"
-                        >
-                            <i class="fas fa-sliders-h filter-toggle-icon" aria-hidden="true"></i>
-                            <span class="filter-toggle-label">Скрыть фильтр</span>
+                    <div class="schedule-week-nav">
+                        <button type="button" class="schedule-btn schedule-btn--nav" id="prev" aria-label="Предыдущая неделя">
+                            <span aria-hidden="true">←</span>
+                        </button>
+                        <div class="schedule-range" id="range"></div>
+                        <button type="button" class="schedule-btn schedule-btn--nav" id="next" aria-label="Следующая неделя">
+                            <span aria-hidden="true">→</span>
                         </button>
                     </div>
-                    <div class="schedule-grid" id="scheduleGrid"></div>
+
+                    <div class="schedule-timeline" id="grid" aria-live="polite"></div>
                 </div>
             </div>
         </section>

--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -1,2013 +1,516 @@
-import { fetchMarketplaces, fetchWarehouses } from './filterOptions.js';
+import { fetchMarketplaces, fetchCities } from './filterOptions.js';
 
-// Управление расписанием отправлений в одноэкранном формате фильтрации
-class ScheduleManager {
+class ScheduleTimeline {
     constructor() {
-        this.schedules = [];
-        this.filteredSchedules = [];
-        this.groupedSchedules = [];
-        this.filters = {
-            marketplace: '',
-            warehouse: ''
-        };
-        this.marketplaceOptions = [];
-        this.warehouseOptions = [];
-        this.isLoadingMarketplaces = false;
-        this.isLoadingWarehouses = false;
-        this.isLoadingSchedules = false;
-        this.schedulesCache = new Map();
-        this.warehouseStats = {
-            isLoading: false,
-            error: '',
-            data: null
-        };
-        this.warehouseStatsCache = new Map();
-        this.currentWarehouseStatsKey = '';
-        this.activeWarehouseStatsController = null;
-        this.scheduleGroupsByKey = new Map();
-        this.boundHandleScheduleGridClick = this.handleScheduleGridClick.bind(this);
-        this.scheduleGridElement = null;
-        this.schedulePanelElement = document.getElementById('schedulePanel');
-        this.filtersContainer = document.getElementById('scheduleFilters');
-        this.scheduleResultsElement = document.querySelector('.schedule-results');
-        this.filterToggleButton = document.getElementById('filterToggleBtn');
-        this.isFiltersCollapsed = false;
-        this.hasAppliedFilterCollapseState = false;
-
         this.elements = {
-            marketplaceSelect: document.getElementById('marketplaceFilter'),
-            warehouseSelect: document.getElementById('warehouseFilter'),
-            resetButton: document.getElementById('resetScheduleFilters'),
-            subtitle: document.getElementById('scheduleSubtitle'),
-            warehouseStats: document.getElementById('warehouseStats')
+            panel: document.getElementById('schedulePanel'),
+            marketplace: document.getElementById('marketplace'),
+            originTabs: document.getElementById('originTabs'),
+            grid: document.getElementById('grid'),
+            prev: document.getElementById('prev'),
+            next: document.getElementById('next'),
+            range: document.getElementById('range')
         };
-        this.stepElements = {
-            marketplaceStep: document.querySelector('[data-step="marketplace"]'),
-            warehouseStep: document.querySelector('[data-step="warehouse"]'),
-            marketplaceSummary: document.getElementById('marketplaceSummary'),
-            warehouseSummary: document.getElementById('warehouseSummary'),
-            marketplaceConfirmBtn: document.getElementById('confirmMarketplace'),
-            warehouseConfirmBtn: document.getElementById('confirmWarehouse'),
-            backToMarketplaceBtn: document.getElementById('backToMarketplaceBtn'),
-            changeMarketplaceBtn: document.getElementById('changeMarketplaceBtn'),
-            changeWarehouseBtn: document.getElementById('changeWarehouseBtn')
-        };
-        this.pendingSelections = {
+
+        this.state = {
             marketplace: '',
-            warehouse: ''
+            city: '',
+            weekStart: this.getMonday(new Date())
         };
-        this.currentStep = 'marketplace';
+
+        this.marketplaceOptions = [];
+        this.cityOptions = [];
+        this.scheduleCache = new Map();
+        this.originalSchedules = [];
+        this.enrichedSchedules = [];
+        this.scheduleLookup = new Map();
+        this.activeRequestController = null;
+        this.isLoading = false;
+        this.errorMessage = '';
+
+        this.handleOriginTabClick = this.handleOriginTabClick.bind(this);
+        this.handleTimelineClick = this.handleTimelineClick.bind(this);
 
         this.init();
     }
 
     init() {
-        this.setupEventListeners();
-        this.setFiltersCollapsed(false);
-        this.applyStepState('marketplace', { active: true, complete: false });
-        this.applyStepState('warehouse', { active: false, complete: false });
-        this.updateMarketplaceConfirmState();
-        this.updateWarehouseConfirmState();
-        this.renderScheduleGrid();
-        this.renderWarehouseStats();
-        this.renderWarehouses();
+        if (!this.elements.panel || !this.elements.grid) {
+            return;
+        }
+
+        this.bindEvents();
+        this.renderWeekRange();
         this.loadMarketplaces();
+        this.loadCities();
+        this.loadSchedules();
     }
 
-    setupEventListeners() {
-        const { marketplaceSelect, warehouseSelect, resetButton } = this.elements;
+    bindEvents() {
+        const { marketplace, originTabs, prev, next, grid } = this.elements;
 
-        if (this.filterToggleButton) {
-            this.filterToggleButton.addEventListener('click', () => {
-                this.toggleFiltersCollapsed();
+        if (marketplace) {
+            marketplace.addEventListener('change', (event) => {
+                this.state.marketplace = (event.target.value || '').trim();
+                this.state.city = '';
+                this.scheduleCache.clear();
+                this.renderWeekRange();
+                this.loadCities();
+                this.loadSchedules();
             });
         }
 
-        if (marketplaceSelect) {
-            marketplaceSelect.addEventListener('click', (event) => {
-                if (marketplaceSelect.classList.contains('is-disabled')) {
-                    return;
-                }
+        if (originTabs) {
+            originTabs.addEventListener('click', this.handleOriginTabClick);
+        }
 
-                const card = event.target.closest('.marketplace-card');
-                if (!card || card.disabled) {
-                    return;
-                }
-
-                const { value } = card.dataset;
-                if (typeof value === 'undefined') {
-                    return;
-                }
-
-                const isSameSelection = card.classList.contains('is-active') && this.pendingSelections.marketplace === value;
-                this.handleMarketplaceChange(isSameSelection ? '' : value);
+        if (prev) {
+            prev.addEventListener('click', () => {
+                this.changeWeek(-1);
             });
         }
 
-        if (warehouseSelect) {
-            warehouseSelect.addEventListener('change', (event) => {
-                this.handleWarehouseChange(event.target.value);
+        if (next) {
+            next.addEventListener('click', () => {
+                this.changeWeek(1);
             });
         }
 
-        if (resetButton) {
-            resetButton.addEventListener('click', () => {
-                this.resetFilters();
-            });
-        }
-
-        const {
-            marketplaceConfirmBtn,
-            warehouseConfirmBtn,
-            backToMarketplaceBtn,
-            changeMarketplaceBtn,
-            changeWarehouseBtn
-        } = this.stepElements;
-
-        if (marketplaceConfirmBtn) {
-            marketplaceConfirmBtn.addEventListener('click', () => {
-                this.confirmMarketplaceSelection();
-            });
-        }
-
-        if (warehouseConfirmBtn) {
-            warehouseConfirmBtn.addEventListener('click', () => {
-                this.confirmWarehouseSelection();
-            });
-        }
-
-        if (backToMarketplaceBtn) {
-            backToMarketplaceBtn.addEventListener('click', () => {
-                this.openMarketplaceStep();
-            });
-        }
-
-        if (changeMarketplaceBtn) {
-            changeMarketplaceBtn.addEventListener('click', () => {
-                this.openMarketplaceStep();
-            });
-        }
-
-        if (changeWarehouseBtn) {
-            changeWarehouseBtn.addEventListener('click', () => {
-                this.openWarehouseStep();
-            });
+        if (grid) {
+            grid.addEventListener('click', this.handleTimelineClick);
         }
     }
 
-    toggleFiltersCollapsed() {
-        const nextState = !this.isFiltersCollapsed;
-        this.setFiltersCollapsed(nextState, { scrollIntoView: nextState });
+    getMonday(date) {
+        const workingDate = new Date(date);
+        const day = workingDate.getDay();
+        const diff = workingDate.getDate() - (day === 0 ? 6 : day - 1);
+        workingDate.setDate(diff);
+        workingDate.setHours(0, 0, 0, 0);
+        return workingDate;
     }
 
-    setFiltersCollapsed(collapsed, { scrollIntoView = false } = {}) {
-        const shouldCollapse = Boolean(collapsed);
-        const wasStateApplied = this.hasAppliedFilterCollapseState;
-        const hasStateChanged = this.isFiltersCollapsed !== shouldCollapse || !wasStateApplied;
+    changeWeek(offset) {
+        const nextWeek = new Date(this.state.weekStart);
+        nextWeek.setDate(nextWeek.getDate() + offset * 7);
+        this.state.weekStart = this.getMonday(nextWeek);
+        this.renderWeek();
+    }
 
-        const schedulePanel = this.schedulePanelElement instanceof HTMLElement ? this.schedulePanelElement : null;
-        const shouldPerformScroll = Boolean(shouldCollapse && scrollIntoView && wasStateApplied && schedulePanel);
-
-        this.isFiltersCollapsed = shouldCollapse;
-
-        if (hasStateChanged && schedulePanel) {
-            schedulePanel.classList.toggle('filters-collapsed', shouldCollapse);
-            schedulePanel.classList.toggle('filters-expanded', !shouldCollapse);
+    async loadMarketplaces() {
+        const select = this.elements.marketplace;
+        if (!select) {
+            return;
         }
 
-        if (shouldPerformScroll) {
-            const performScroll = () => {
-                const desktopNav = document.querySelector('.desktop-nav');
+        select.disabled = true;
 
-                if (desktopNav instanceof HTMLElement) {
-                    const headerRect = desktopNav.getBoundingClientRect();
-                    const scheduleRect = schedulePanel.getBoundingClientRect();
-                    const headerHeight = headerRect.height;
-                    const currentScroll = window.pageYOffset || document.documentElement.scrollTop || 0;
-                    const targetScroll = Math.max(0, scheduleRect.top + currentScroll - headerHeight);
+        try {
+            const marketplaces = await fetchMarketplaces({ baseUrl: '../filter_options.php' });
+            this.marketplaceOptions = Array.isArray(marketplaces) ? marketplaces : [];
+        } catch (error) {
+            console.error('Ошибка загрузки маркетплейсов:', error);
+            this.marketplaceOptions = [];
+        } finally {
+            this.renderMarketplaceOptions();
+            select.disabled = false;
+        }
+    }
 
-                    window.scrollTo({ top: targetScroll, behavior: 'smooth' });
-                    return;
-                }
+    renderMarketplaceOptions() {
+        const select = this.elements.marketplace;
+        if (!select) {
+            return;
+        }
 
-                schedulePanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            };
+        const currentValue = this.state.marketplace || '';
+        select.innerHTML = '';
 
-            const filtersContainer = this.filtersContainer instanceof HTMLElement ? this.filtersContainer : null;
+        const defaultOption = document.createElement('option');
+        defaultOption.value = '';
+        defaultOption.textContent = 'Все маркетплейсы';
+        select.appendChild(defaultOption);
 
-            if (hasStateChanged && filtersContainer) {
-                const parseTimeToMs = (value) => {
-                    if (typeof value !== 'string') {
-                        return 0;
-                    }
-
-                    const trimmedValue = value.trim();
-                    if (!trimmedValue) {
-                        return 0;
-                    }
-
-                    if (trimmedValue.endsWith('ms')) {
-                        return Number.parseFloat(trimmedValue);
-                    }
-
-                    if (trimmedValue.endsWith('s')) {
-                        return Number.parseFloat(trimmedValue) * 1000;
-                    }
-
-                    return 0;
-                };
-
-                const computeFallbackDelay = () => {
-                    const styles = window.getComputedStyle(filtersContainer);
-                    const rawDurations = styles.transitionDuration.split(',');
-                    const rawDelays = styles.transitionDelay.split(',');
-
-                    const maxEntries = Math.max(rawDurations.length, rawDelays.length);
-                    let maxTime = 0;
-
-                    for (let index = 0; index < maxEntries; index += 1) {
-                        const duration = parseTimeToMs(rawDurations[index] ?? rawDurations[rawDurations.length - 1] ?? '0s');
-                        const delay = parseTimeToMs(rawDelays[index] ?? rawDelays[rawDelays.length - 1] ?? '0s');
-
-                        maxTime = Math.max(maxTime, duration + delay);
-                    }
-
-                    return maxTime || 300;
-                };
-
-                let fallbackTimeoutId = null;
-
-                const cleanup = () => {
-                    if (fallbackTimeoutId !== null) {
-                        window.clearTimeout(fallbackTimeoutId);
-                        fallbackTimeoutId = null;
-                    }
-
-                    filtersContainer.removeEventListener('transitionend', handleTransitionEnd);
-                };
-
-                const handleTransitionEnd = (event) => {
-                    if (event.propertyName !== 'max-height') {
-                        filtersContainer.addEventListener('transitionend', handleTransitionEnd, { once: true });
-                        return;
-                    }
-
-                    cleanup();
-                    performScroll();
-                };
-
-                filtersContainer.addEventListener('transitionend', handleTransitionEnd, { once: true });
-
-                fallbackTimeoutId = window.setTimeout(() => {
-                    cleanup();
-                    performScroll();
-                }, computeFallbackDelay());
-            } else {
-                performScroll();
+        this.marketplaceOptions.forEach((marketplace) => {
+            if (!marketplace) {
+                return;
             }
-        }
 
-        this.hasAppliedFilterCollapseState = true;
-        this.updateFilterToggleButton();
+            const option = document.createElement('option');
+            option.value = marketplace;
+            option.textContent = marketplace;
+            select.appendChild(option);
+        });
+
+        select.value = currentValue;
     }
 
-    updateFilterToggleButton() {
-        const button = this.filterToggleButton;
-        if (!(button instanceof HTMLElement)) {
-            return;
-        }
-
-        const isCollapsed = this.isFiltersCollapsed;
-        const label = button.querySelector('.filter-toggle-label');
-        if (label) {
-            label.textContent = isCollapsed ? 'ФИЛЬТР' : 'Скрыть фильтр';
-        }
-
-        const icon = button.querySelector('.filter-toggle-icon');
-        if (icon) {
-            icon.className = `fas ${isCollapsed ? 'fa-sliders-h' : 'fa-chevron-up'} filter-toggle-icon`;
-        }
-
-        button.setAttribute('aria-expanded', isCollapsed ? 'false' : 'true');
-        button.setAttribute('aria-label', isCollapsed ? 'Открыть фильтр расписания' : 'Скрыть фильтр расписания');
-    }
-
-    applyStepState(stepName, { active = false, complete = false } = {}) {
-        const stepKey = `${stepName}Step`;
-        const step = this.stepElements[stepKey];
-        if (!step) {
-            return;
-        }
-
-        step.classList.toggle('is-active', active);
-        step.classList.toggle('is-complete', complete);
-    }
-
-    handleMarketplaceChange(value) {
-        this.pendingSelections.marketplace = value;
-        this.updateMarketplaceConfirmState();
-        this.setActiveMarketplaceCard(value);
-
-        this.pendingSelections.warehouse = '';
-        this.updateWarehouseConfirmState();
-        this.applyStepState('warehouse', { active: false, complete: false });
-        this.clearWarehouseSummary();
-
-        if (!value) {
-            this.clearMarketplaceSummary();
-        }
-    }
-
-    setActiveMarketplaceCard(value) {
-        const container = this.elements.marketplaceSelect;
+    async loadCities() {
+        const container = this.elements.originTabs;
         if (!container) {
             return;
         }
 
-        const cards = container.querySelectorAll('.marketplace-card');
-        cards.forEach((card) => {
-            const isActive = Boolean(value) && card.dataset.value === value;
-            card.classList.toggle('is-active', isActive);
-            card.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-        });
-    }
+        container.classList.remove('is-hidden');
+        container.innerHTML = '';
 
-    updateMarketplaceConfirmState() {
-        const button = this.stepElements.marketplaceConfirmBtn;
-        if (button) {
-            button.disabled = !this.pendingSelections.marketplace;
-        }
-    }
-
-    confirmMarketplaceSelection() {
-        if (!this.pendingSelections.marketplace) {
-            return;
-        }
-
-        this.selectMarketplace(this.pendingSelections.marketplace);
-        this.pendingSelections.marketplace = this.filters.marketplace;
-        this.showMarketplaceSummary();
-        this.applyStepState('marketplace', { active: false, complete: true });
-        this.applyStepState('warehouse', { active: true, complete: false });
-        this.currentStep = 'warehouse';
-        this.pendingSelections.warehouse = '';
-        this.updateWarehouseConfirmState();
-        this.clearWarehouseSummary();
-        this.setFiltersCollapsed(false);
-    }
-
-    openMarketplaceStep() {
-        this.currentStep = 'marketplace';
-        this.applyStepState('marketplace', { active: true, complete: false });
-        const hasWarehouse = Boolean(this.filters.warehouse);
-        this.applyStepState('warehouse', { active: false, complete: hasWarehouse });
-        this.pendingSelections.marketplace = this.filters.marketplace || '';
-        this.updateMarketplaceConfirmState();
-        this.pendingSelections.warehouse = this.filters.warehouse || '';
-        this.updateWarehouseConfirmState();
-        this.setActiveMarketplaceCard(this.pendingSelections.marketplace);
-        this.setFiltersCollapsed(false);
-    }
-
-    openWarehouseStep() {
-        if (!this.filters.marketplace) {
-            this.openMarketplaceStep();
-            return;
-        }
-
-        this.currentStep = 'warehouse';
-        this.applyStepState('marketplace', { active: false, complete: true });
-        this.applyStepState('warehouse', { active: true, complete: false });
-        this.pendingSelections.warehouse = this.filters.warehouse || '';
-        this.updateWarehouseConfirmState();
-        this.setFiltersCollapsed(false);
-
-        if (this.elements.warehouseSelect) {
-            this.elements.warehouseSelect.value = this.filters.warehouse || '';
-        }
-    }
-
-    handleWarehouseChange(value) {
-        this.pendingSelections.warehouse = value;
-        this.updateWarehouseConfirmState();
-        this.applyStepState('warehouse', { active: true, complete: false });
-
-        if (!value) {
-            this.clearWarehouseSummary();
-            this.setFiltersCollapsed(false);
-        }
-    }
-
-    updateWarehouseConfirmState() {
-        const button = this.stepElements.warehouseConfirmBtn;
-        if (button) {
-            const hasMarketplace = Boolean(this.filters.marketplace || this.pendingSelections.marketplace);
-            button.disabled = !hasMarketplace || !this.pendingSelections.warehouse;
-        }
-    }
-
-    confirmWarehouseSelection() {
-        if (!this.pendingSelections.warehouse) {
-            return;
-        }
-
-        this.selectWarehouse(this.pendingSelections.warehouse);
-        this.pendingSelections.warehouse = this.filters.warehouse;
-        this.showWarehouseSummary();
-        this.applyStepState('warehouse', { active: false, complete: true });
-        this.setFiltersCollapsed(true, { scrollIntoView: true });
-    }
-
-    showMarketplaceSummary() {
-        const summary = this.stepElements.marketplaceSummary;
-        if (!summary) {
-            return;
-        }
-
-        if (!this.filters.marketplace) {
-            summary.textContent = '';
-            return;
-        }
-
-        const label = this.getMarketplaceLabel(this.filters.marketplace);
-        summary.textContent = label ? `Маркетплейс: ${label}` : '';
-    }
-
-    showWarehouseSummary() {
-        const summary = this.stepElements.warehouseSummary;
-        if (!summary) {
-            return;
-        }
-
-        if (!this.filters.warehouse) {
-            summary.textContent = '';
-            return;
-        }
-
-        summary.textContent = `Склад: ${this.filters.warehouse}`;
-    }
-
-    clearMarketplaceSummary() {
-        const summary = this.stepElements.marketplaceSummary;
-        if (summary) {
-            summary.textContent = '';
-        }
-    }
-
-    clearWarehouseSummary() {
-        const summary = this.stepElements.warehouseSummary;
-        if (summary) {
-            summary.textContent = '';
-        }
-    }
-
-    clearWarehouseStats() {
-        this.abortWarehouseStatsRequest();
-        this.warehouseStats = {
-            isLoading: false,
-            error: '',
-            data: null
-        };
-        this.currentWarehouseStatsKey = '';
-
-        const container = this.elements.warehouseStats;
-        if (container) {
-            container.classList.remove('is-visible');
-            container.innerHTML = '';
-            container.setAttribute('aria-hidden', 'true');
-        }
-    }
-
-    abortWarehouseStatsRequest() {
-        if (this.activeWarehouseStatsController) {
-            this.activeWarehouseStatsController.abort();
-            this.activeWarehouseStatsController = null;
-        }
-    }
-
-    updateScheduleSubtitle(message) {
-        const subtitle = this.elements.subtitle || document.getElementById('scheduleSubtitle');
-        if (subtitle) {
-            subtitle.textContent = message;
-        }
-    }
-
-    async loadMarketplaces() {
-        this.isLoadingMarketplaces = true;
-        this.renderMarketplaces();
+        const placeholder = document.createElement('span');
+        placeholder.className = 'schedule-origin-placeholder';
+        placeholder.textContent = 'Загрузка городов...';
+        container.appendChild(placeholder);
 
         try {
-            const marketplaces = await fetchMarketplaces({ baseUrl: '../filter_options.php' });
-            this.marketplaceOptions = marketplaces.map(mp => ({
-                value: mp,
-                label: mp,
-                description: this.getMarketplaceDescription(mp)
-            }));
+            const cities = await fetchCities({ marketplace: this.state.marketplace, baseUrl: '../filter_options.php' });
+            this.cityOptions = Array.isArray(cities)
+                ? cities.filter((city) => typeof city === 'string' && city.trim().length > 0)
+                : [];
         } catch (error) {
-            console.error('Ошибка загрузки маркетплейсов:', error);
-            this.showError('Не удалось загрузить список маркетплейсов');
-            this.marketplaceOptions = [];
-        } finally {
-            this.isLoadingMarketplaces = false;
-            this.renderMarketplaces();
+            console.error('Ошибка загрузки городов:', error);
+            this.cityOptions = [];
         }
+
+        if (this.state.city && !this.cityOptions.includes(this.state.city)) {
+            this.state.city = '';
+        }
+
+        this.renderOriginTabs();
     }
 
-    renderMarketplaces() {
-        const container = this.elements.marketplaceSelect;
-        if (!container) return;
+    renderOriginTabs() {
+        const container = this.elements.originTabs;
+        if (!container) {
+            return;
+        }
 
         container.innerHTML = '';
-        container.classList.remove('is-loading', 'is-disabled');
-        container.removeAttribute('aria-busy');
-        container.removeAttribute('aria-disabled');
 
-        if (this.isLoadingMarketplaces) {
-            container.classList.add('is-loading');
-            container.setAttribute('aria-busy', 'true');
-            container.appendChild(this.createMarketplaceMessage('Загрузка маркетплейсов...', { isLoading: true }));
+        if (!this.cityOptions || this.cityOptions.length === 0) {
+            container.classList.add('is-hidden');
+            container.setAttribute('aria-hidden', 'true');
             return;
         }
 
-        if (this.marketplaceOptions.length === 0) {
-            container.classList.add('is-disabled');
-            container.setAttribute('aria-disabled', 'true');
-            container.appendChild(this.createMarketplaceMessage('Маркетплейсы недоступны'));
+        container.classList.remove('is-hidden');
+        container.removeAttribute('aria-hidden');
+
+        const fragment = document.createDocumentFragment();
+        fragment.appendChild(this.createOriginTab('', 'Все города отправления'));
+
+        this.cityOptions.forEach((city) => {
+            fragment.appendChild(this.createOriginTab(city, city));
+        });
+
+        container.appendChild(fragment);
+        this.updateActiveOriginTab();
+    }
+
+    createOriginTab(value, label) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'schedule-origin-tab';
+        button.dataset.origin = value || '';
+        button.textContent = label;
+        button.setAttribute('role', 'tab');
+        button.setAttribute('aria-selected', 'false');
+        return button;
+    }
+
+    updateActiveOriginTab() {
+        const container = this.elements.originTabs;
+        if (!container) {
             return;
         }
 
-        const activeValue = this.pendingSelections.marketplace || this.filters.marketplace || '';
+        const activeValue = this.state.city || '';
+        const tabs = container.querySelectorAll('.schedule-origin-tab');
 
-        this.marketplaceOptions.forEach(optionData => {
-            const card = document.createElement('button');
-            card.type = 'button';
-            card.className = 'marketplace-card';
-            card.dataset.value = optionData.value;
-            card.dataset.label = optionData.label;
-            card.title = optionData.description || optionData.label;
-
-            const title = document.createElement('span');
-            title.className = 'marketplace-card__title';
-            title.textContent = optionData.label;
-            card.appendChild(title);
-
-            if (optionData.description) {
-                const description = document.createElement('span');
-                description.className = 'marketplace-card__description';
-                description.textContent = optionData.description;
-                card.appendChild(description);
-            }
-
-            const isActive = Boolean(activeValue) && optionData.value === activeValue;
-            card.classList.toggle('is-active', isActive);
-            card.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-
-            container.appendChild(card);
+        tabs.forEach((tab) => {
+            const tabValue = tab.dataset.origin || '';
+            const isActive = tabValue === activeValue;
+            tab.classList.toggle('is-active', isActive);
+            tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
         });
     }
 
-    createMarketplaceMessage(text, { isLoading = false } = {}) {
-        const message = document.createElement('div');
-        message.className = 'marketplace-placeholder';
-        if (isLoading) {
-            message.classList.add('marketplace-placeholder--loading');
-        }
-
-        message.setAttribute('role', isLoading ? 'status' : 'note');
-        message.setAttribute('aria-live', 'polite');
-
-        const span = document.createElement('span');
-        span.textContent = text;
-        message.appendChild(span);
-        return message;
-    }
-
-    getMarketplaceDescription(marketplace) {
-        const descriptions = {
-            'Wildberries': 'Крупнейший российский маркетплейс',
-            'Ozon': 'Универсальная торговая площадка',
-            'YandexMarket': 'Маркетплейс от Яндекса'
-        };
-        return descriptions[marketplace] || 'Торговая площадка';
-    }
-
-    getMarketplaceLabel(value) {
-        if (!value) {
-            return '';
-        }
-
-        const option = this.marketplaceOptions.find(item => item.value === value);
-        return option ? option.label : value;
-    }
-
-    selectMarketplace(marketplace) {
-        this.filters.marketplace = marketplace;
-        this.filters.warehouse = '';
-
-        this.pendingSelections.marketplace = marketplace;
-        this.pendingSelections.warehouse = '';
-        this.updateMarketplaceConfirmState();
-        this.updateWarehouseConfirmState();
-        this.clearWarehouseSummary();
-        this.clearWarehouseStats();
-
-        if (this.elements.warehouseSelect) {
-            this.elements.warehouseSelect.value = '';
-        }
-
-        this.warehouseOptions = [];
-        this.schedules = [];
-        this.filteredSchedules = [];
-        this.groupedSchedules = [];
-        this.isLoadingSchedules = false;
-        this.scheduleGroupsByKey.clear();
-
-        this.renderMarketplaces();
-        this.renderWarehouses();
-        this.renderScheduleGrid();
-
-        if (marketplace) {
-            this.loadWarehouses();
-        }
-    }
-
-    async loadWarehouses() {
-        if (!this.filters.marketplace) {
-            this.warehouseOptions = [];
-            this.renderWarehouses();
+    handleOriginTabClick(event) {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
             return;
         }
 
-        this.isLoadingWarehouses = true;
-        this.renderWarehouses();
-
-        try {
-            const warehouses = await fetchWarehouses({
-                marketplace: this.filters.marketplace,
-                baseUrl: '../filter_options.php'
-            });
-
-            this.warehouseOptions = warehouses.map(wh => ({
-                value: wh,
-                label: wh
-            }));
-        } catch (error) {
-            console.error('Ошибка загрузки складов:', error);
-            this.showError('Не удалось загрузить список складов');
-            this.warehouseOptions = [];
-        } finally {
-            this.isLoadingWarehouses = false;
-            this.renderWarehouses();
-        }
-    }
-
-    renderWarehouses() {
-        const select = this.elements.warehouseSelect;
-        if (!select) return;
-
-        select.innerHTML = '';
-
-        if (!this.filters.marketplace) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'Сначала выберите маркетплейс';
-            select.appendChild(option);
-            select.disabled = true;
+        const button = target.closest('.schedule-origin-tab');
+        if (!button) {
             return;
         }
 
-        if (this.isLoadingWarehouses) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'Загрузка складов...';
-            option.disabled = true;
-            select.appendChild(option);
-            select.disabled = true;
+        const value = button.dataset.origin || '';
+        if (value === (this.state.city || '')) {
             return;
         }
 
-        if (this.warehouseOptions.length === 0) {
-            const option = document.createElement('option');
-            option.value = '';
-            option.textContent = 'Нет доступных складов';
-            option.disabled = true;
-            select.appendChild(option);
-            select.disabled = true;
-            return;
-        }
-
-        const placeholderOption = document.createElement('option');
-        placeholderOption.value = '';
-        placeholderOption.textContent = 'Выберите склад';
-        select.appendChild(placeholderOption);
-
-        this.warehouseOptions.forEach(optionData => {
-            const option = document.createElement('option');
-            option.value = optionData.value;
-            option.textContent = optionData.label;
-            select.appendChild(option);
-        });
-
-        select.disabled = false;
-        const selected = this.filters.warehouse || '';
-        select.value = selected;
-        if (select.value !== selected) {
-            select.value = '';
-        }
-    }
-
-    selectWarehouse(warehouse) {
-        this.filters.warehouse = warehouse;
-        this.pendingSelections.warehouse = warehouse;
-        this.updateWarehouseConfirmState();
-
-        if (!warehouse) {
-            this.filteredSchedules = [];
-            this.groupedSchedules = [];
-            this.scheduleGroupsByKey.clear();
-            this.renderScheduleGrid();
-            this.clearWarehouseSummary();
-            this.clearWarehouseStats();
-            this.setFiltersCollapsed(false);
-            return;
-        }
-
+        this.state.city = value;
+        this.updateActiveOriginTab();
         this.loadSchedules();
-        this.fetchWarehouseOrdersStats(this.filters.marketplace, warehouse);
-        this.renderWarehouseStats();
     }
 
-    createWarehouseStatsKey(marketplace, warehouse) {
-        if (!marketplace || !warehouse) {
-            return '';
-        }
-
-        const normalize = (value) => String(value).trim().toLowerCase();
-        return `${normalize(marketplace)}__${normalize(warehouse)}`;
-    }
-
-    async fetchWarehouseOrdersStats(marketplace, warehouse) {
-        if (!marketplace || !warehouse) {
-            this.warehouseStats = {
-                isLoading: false,
-                error: '',
-                data: null
-            };
-            this.currentWarehouseStatsKey = '';
-            this.renderWarehouseStats();
+    handleTimelineClick(event) {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
             return;
         }
 
-        const cacheKey = this.createWarehouseStatsKey(marketplace, warehouse);
-        this.currentWarehouseStatsKey = cacheKey;
+        const button = target.closest('.schedule-shipment');
+        if (!button) {
+            return;
+        }
 
-        const cached = this.warehouseStatsCache.get(cacheKey);
+        const scheduleId = button.dataset.scheduleId || '';
+        const entry = this.scheduleLookup.get(scheduleId);
+        if (!entry) {
+            return;
+        }
+
+        event.preventDefault();
+        this.openScheduleDetails(entry);
+    }
+
+    async loadSchedules() {
+        if (!this.elements.grid) {
+            return;
+        }
+
+        const cacheKey = JSON.stringify({
+            marketplace: this.state.marketplace || '',
+            city: this.state.city || ''
+        });
+
+        const cached = this.scheduleCache.get(cacheKey);
         if (cached) {
-            this.warehouseStats = {
-                isLoading: false,
-                error: '',
-                data: cached
-            };
-            this.renderWarehouseStats();
+            this.updateSchedules(cached);
+            this.errorMessage = '';
+            this.isLoading = false;
+            this.renderWeek();
             return;
         }
 
-        this.abortWarehouseStatsRequest();
+        if (this.activeRequestController) {
+            this.activeRequestController.abort();
+        }
 
         const controller = new AbortController();
-        this.activeWarehouseStatsController = controller;
-
-        this.warehouseStats = {
-            isLoading: true,
-            error: '',
-            data: null
-        };
-        this.renderWarehouseStats();
+        this.activeRequestController = controller;
+        this.errorMessage = '';
+        this.isLoading = true;
+        this.renderWeek();
 
         try {
-            const params = new URLSearchParams({ marketplace, warehouse });
-            const response = await fetch(`../get_warehouse_stats.php?${params.toString()}`, {
-                credentials: 'include',
-                signal: controller.signal
-            });
-
-            if (!response.ok) {
-                throw new Error(`Ошибка загрузки статистики: ${response.status}`);
-            }
-
-            const payload = await response.json();
-
-            if (!payload || payload.success === false) {
-                const message = payload && typeof payload.message === 'string'
-                    ? payload.message
-                    : 'Не удалось получить статистику заказов';
-                throw new Error(message);
-            }
-
-            const normalized = this.normalizeWarehouseStatsResponse(payload);
-            this.warehouseStatsCache.set(cacheKey, normalized);
-
-            if (this.currentWarehouseStatsKey !== cacheKey) {
-                return;
-            }
-
-            this.warehouseStats = {
-                isLoading: false,
-                error: '',
-                data: normalized
-            };
+            const data = await this.fetchSchedules(controller.signal);
+            this.scheduleCache.set(cacheKey, data);
+            this.updateSchedules(data);
         } catch (error) {
             if (error.name === 'AbortError') {
                 return;
             }
 
-            console.error('Ошибка загрузки статистики склада:', error);
-
-            if (this.currentWarehouseStatsKey !== cacheKey) {
-                return;
-            }
-
-            this.warehouseStats = {
-                isLoading: false,
-                error: 'Не удалось загрузить статистику заказов',
-                data: null
-            };
-        } finally {
-            if (this.activeWarehouseStatsController === controller) {
-                this.activeWarehouseStatsController = null;
-            }
-
-            if (this.currentWarehouseStatsKey === cacheKey) {
-                this.renderWarehouseStats();
-            }
-        }
-    }
-
-    renderWarehouseStats() {
-        const container = this.elements.warehouseStats;
-        if (!container) {
-            return;
-        }
-
-        const hasSelection = Boolean(this.filters.marketplace && this.filters.warehouse);
-        container.classList.toggle('is-visible', hasSelection);
-
-        if (!hasSelection) {
-            container.innerHTML = '';
-            container.setAttribute('aria-hidden', 'true');
-            return;
-        }
-
-        container.removeAttribute('aria-hidden');
-
-        const fragment = document.createDocumentFragment();
-        const header = document.createElement('div');
-        header.className = 'warehouse-stats__header';
-
-        const title = document.createElement('span');
-        title.className = 'warehouse-stats__title';
-        title.textContent = 'Статистика склада';
-        header.appendChild(title);
-
-        const meta = document.createElement('span');
-        meta.className = 'warehouse-stats__subtitle';
-        const marketplaceLabel = this.getMarketplaceLabel(this.filters.marketplace) || this.filters.marketplace;
-        const metaParts = [];
-        if (this.filters.warehouse) {
-            metaParts.push(`Склад «${this.filters.warehouse}»`);
-        }
-        if (marketplaceLabel) {
-            metaParts.push(`Маркетплейс «${marketplaceLabel}»`);
-        }
-        if (metaParts.length > 0) {
-            meta.textContent = metaParts.join(' · ');
-            header.appendChild(meta);
-        }
-        fragment.appendChild(header);
-
-        const grid = document.createElement('div');
-        grid.className = 'warehouse-stats__grid';
-
-        if (this.isLoadingSchedules) {
-            grid.appendChild(this.createWarehouseStatsLoadingItem('Отправления', 'Загружаем расписание...'));
-        } else {
-            const stats = this.getWarehouseDepartureStats();
-            const description = stats.uniqueDepartureDates === 0
-                ? 'Нет активных отправлений'
-                : `По уникальным датам выезда (${this.formatNumber(stats.totalSchedules)} расписаний)`;
-
-            grid.appendChild(this.createWarehouseStatsItem({
-                label: 'Отправления',
-                value: this.formatNumber(stats.uniqueDepartureDates),
-                description
-            }));
-        }
-
-        if (this.warehouseStats.isLoading) {
-            grid.appendChild(this.createWarehouseStatsLoadingItem('Заказы', 'Обновляем статистику заказов...'));
-        } else if (this.warehouseStats.error) {
-            grid.appendChild(this.createWarehouseStatsErrorItem('Заказы', this.warehouseStats.error));
-        } else {
-            const stats = this.warehouseStats.data || {
-                ordersTotal: 0,
-                ordersForWarehouse: 0,
-                ordersPercentage: 0
-            };
-
-            const hasOrders = stats.ordersTotal > 0;
-            const ordersValue = this.formatNumber(stats.ordersForWarehouse);
-            const description = hasOrders
-                ? `${this.formatPercentage(stats.ordersPercentage)}% от ${this.formatNumber(stats.ordersTotal)} заказов`
-                : 'Для этого маркетплейса ещё нет заказов';
-
-            grid.appendChild(this.createWarehouseStatsItem({
-                label: 'Заказы',
-                value: ordersValue,
-                description
-            }));
-        }
-
-        fragment.appendChild(grid);
-
-        const note = document.createElement('p');
-        note.className = 'warehouse-stats__note';
-        note.textContent = 'Статистика заказов учитывает только выбранный маркетплейс.';
-        fragment.appendChild(note);
-
-        container.innerHTML = '';
-        container.appendChild(fragment);
-    }
-
-    createWarehouseStatsItem({ label, value = '', description = '', modifier = '' }) {
-        const item = document.createElement('div');
-        item.className = 'warehouse-stats__item';
-        if (modifier) {
-            item.classList.add(`warehouse-stats__item--${modifier}`);
-        }
-
-        const labelEl = document.createElement('span');
-        labelEl.className = 'warehouse-stats__label';
-        labelEl.textContent = label;
-        item.appendChild(labelEl);
-
-        const valueEl = document.createElement('span');
-        valueEl.className = 'warehouse-stats__value';
-
-        if (modifier === 'loading') {
-            const spinner = document.createElement('span');
-            spinner.className = 'warehouse-stats__spinner';
-            spinner.setAttribute('aria-hidden', 'true');
-            valueEl.appendChild(spinner);
-        } else if (value !== null && value !== undefined && value !== '') {
-            valueEl.textContent = value;
-        } else {
-            valueEl.textContent = '—';
-        }
-
-        item.appendChild(valueEl);
-
-        if (description) {
-            const descriptionEl = document.createElement('span');
-            descriptionEl.className = 'warehouse-stats__description';
-            descriptionEl.textContent = description;
-            item.appendChild(descriptionEl);
-        }
-
-        return item;
-    }
-
-    createWarehouseStatsLoadingItem(label, message) {
-        return this.createWarehouseStatsItem({
-            label,
-            description: message,
-            modifier: 'loading'
-        });
-    }
-
-    createWarehouseStatsErrorItem(label, message) {
-        return this.createWarehouseStatsItem({
-            label,
-            description: message,
-            modifier: 'error'
-        });
-    }
-
-    getWarehouseDepartureStats() {
-        if (!Array.isArray(this.filteredSchedules) || this.filteredSchedules.length === 0) {
-            return {
-                totalSchedules: 0,
-                uniqueDepartureDates: 0
-            };
-        }
-
-        const uniqueDates = new Set();
-        let total = 0;
-
-        this.filteredSchedules.forEach((schedule) => {
-            if (!schedule) {
-                return;
-            }
-
-            total += 1;
-            const departureKey = this.getScheduleDepartureKey(schedule);
-            if (departureKey) {
-                uniqueDates.add(departureKey);
-            }
-        });
-
-        return {
-            totalSchedules: total,
-            uniqueDepartureDates: uniqueDates.size
-        };
-    }
-
-    getScheduleDepartureKey(schedule) {
-        const value = schedule?.departure_date
-            || schedule?.departureDate
-            || schedule?.accept_date
-            || schedule?.acceptDate
-            || '';
-
-        if (!value) {
-            return '';
-        }
-
-        const raw = String(value).trim();
-        if (!raw) {
-            return '';
-        }
-
-        if (raw.includes('T')) {
-            return raw.split('T')[0];
-        }
-
-        if (raw.includes(' ')) {
-            return raw.split(' ')[0];
-        }
-
-        return raw;
-    }
-
-    getScheduleDeliveryKey(schedule) {
-        const value = schedule?.delivery_date
-            || schedule?.deliveryDate
-            || '';
-
-        if (!value) {
-            return '';
-        }
-
-        const raw = String(value).trim();
-        if (!raw) {
-            return '';
-        }
-
-        if (raw.includes('T')) {
-            return raw.split('T')[0];
-        }
-
-        if (raw.includes(' ')) {
-            return raw.split(' ')[0];
-        }
-
-        return raw;
-    }
-
-    parseLocalDate(value) {
-        if (!value) {
-            return null;
-        }
-
-        const raw = String(value).trim();
-        if (!raw) {
-            return null;
-        }
-
-        const [sanitized] = raw.split(/[T ]/);
-
-        const isoMatch = sanitized.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-        if (isoMatch) {
-            const year = Number(isoMatch[1]);
-            const month = Number(isoMatch[2]);
-            const day = Number(isoMatch[3]);
-
-            if (!Number.isNaN(year) && !Number.isNaN(month) && !Number.isNaN(day)) {
-                const date = new Date(year, month - 1, day);
-                if (!Number.isNaN(date.getTime())) {
-                    return date;
-                }
-            }
-        }
-
-        const dottedMatch = sanitized.match(/^(\d{2})\.(\d{2})\.(\d{4})$/);
-        if (dottedMatch) {
-            const day = Number(dottedMatch[1]);
-            const month = Number(dottedMatch[2]);
-            const year = Number(dottedMatch[3]);
-
-            if (!Number.isNaN(year) && !Number.isNaN(month) && !Number.isNaN(day)) {
-                const date = new Date(year, month - 1, day);
-                if (!Number.isNaN(date.getTime())) {
-                    return date;
-                }
-            }
-        }
-
-        const fallback = Date.parse(raw);
-        if (!Number.isNaN(fallback)) {
-            const parsed = new Date(fallback);
-            const date = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
-            if (!Number.isNaN(date.getTime())) {
-                return date;
-            }
-        }
-
-        return null;
-    }
-
-    isScheduleInFuture(schedule) {
-        const departureKey = this.getScheduleDepartureKey(schedule);
-        if (!departureKey) {
-            return true;
-        }
-
-        const departureDate = this.parseLocalDate(departureKey);
-        if (!departureDate) {
-            return true;
-        }
-
-        const today = new Date();
-        const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
-        const departureStart = new Date(
-            departureDate.getFullYear(),
-            departureDate.getMonth(),
-            departureDate.getDate()
-        ).getTime();
-
-        if (Number.isNaN(departureStart)) {
-            return true;
-        }
-
-        return departureStart >= todayStart;
-    }
-
-    normalizeScheduleForModal(schedule) {
-        if (!schedule || typeof schedule !== 'object') {
-            return {
-                id: '',
-                city: '',
-                warehouse: '',
-                warehouses: '',
-                accept_date: '',
-                acceptDate: '',
-                delivery_date: '',
-                deliveryDate: '',
-                accept_time: '',
-                acceptTime: '',
-                driver_name: '',
-                driverName: '',
-                driver_phone: '',
-                driverPhone: '',
-                car_number: '',
-                carNumber: '',
-                car_brand: '',
-                carBrand: '',
-                sender: '',
-                marketplace: ''
-            };
-        }
-
-        const city = schedule.city
-            || schedule.city_name
-            || schedule.route_city
-            || '';
-        const warehouse = schedule.warehouses
-            || schedule.warehouse
-            || schedule.route_warehouse
-            || '';
-        const acceptDate = schedule.accept_date
-            || schedule.acceptDate
-            || schedule.departure_date
-            || schedule.departureDate
-            || '';
-        const deliveryDate = schedule.delivery_date
-            || schedule.deliveryDate
-            || '';
-        const acceptTime = schedule.accept_time
-            || schedule.acceptTime
-            || '';
-        const driverName = schedule.driver_name
-            || schedule.driverName
-            || '';
-        const driverPhone = schedule.driver_phone
-            || schedule.driverPhone
-            || '';
-        const carNumber = schedule.car_number
-            || schedule.carNumber
-            || '';
-        const carBrand = schedule.car_brand
-            || schedule.carBrand
-            || '';
-        const sender = schedule.sender
-            || schedule.company_name
-            || '';
-        const marketplace = schedule.marketplace
-            || '';
-
-        return {
-            id: schedule.id ?? schedule.schedule_id ?? '',
-            city,
-            warehouse,
-            warehouses: warehouse,
-            accept_date: acceptDate,
-            acceptDate,
-            delivery_date: deliveryDate,
-            deliveryDate,
-            accept_time: acceptTime,
-            acceptTime,
-            driver_name: driverName,
-            driverName,
-            driver_phone: driverPhone,
-            driverPhone,
-            car_number: carNumber,
-            carNumber,
-            car_brand: carBrand,
-            carBrand,
-            sender,
-            marketplace
-        };
-    }
-
-    groupSchedulesByDate(schedules) {
-        const groups = new Map();
-
-        (Array.isArray(schedules) ? schedules : []).forEach((schedule) => {
-            if (!schedule || !this.isScheduleInFuture(schedule)) {
-                return;
-            }
-
-            const details = this.normalizeScheduleForModal(schedule);
-            const departureKey = this.getScheduleDepartureKey(schedule)
-                || details.accept_date
-                || details.acceptDate
-                || '';
-
-            const key = departureKey || `schedule_${details.id || Math.random().toString(36).slice(2)}`;
-            if (!groups.has(key)) {
-                groups.set(key, {
-                    key,
-                    departureDate: departureKey,
-                    schedules: [],
-                    scheduleDetails: [],
-                    cities: new Set(),
-                    deliveryDates: new Set(),
-                    acceptTimes: new Set(),
-                    statuses: new Set(),
-                    marketplace: details.marketplace || '',
-                    warehouse: details.warehouse || details.warehouses || '',
-                    primaryScheduleId: details.id || ''
-                });
-            }
-
-            const group = groups.get(key);
-            group.schedules.push(schedule);
-            group.scheduleDetails.push(details);
-
-            if (details.city) {
-                group.cities.add(details.city);
-            }
-
-            const deliveryKey = this.getScheduleDeliveryKey(schedule)
-                || details.delivery_date
-                || details.deliveryDate;
-            if (deliveryKey) {
-                group.deliveryDates.add(deliveryKey);
-            }
-
-            const acceptTime = details.accept_time || details.acceptTime;
-            if (acceptTime) {
-                group.acceptTimes.add(acceptTime);
-            }
-
-            if (schedule && schedule.status) {
-                group.statuses.add(schedule.status);
-            }
-
-            if (!group.marketplace && details.marketplace) {
-                group.marketplace = details.marketplace;
-            }
-
-            if (!group.warehouse && (details.warehouse || details.warehouses)) {
-                group.warehouse = details.warehouse || details.warehouses;
-            }
-
-            if (!group.primaryScheduleId && details.id) {
-                group.primaryScheduleId = details.id;
-            }
-        });
-
-        const toTimestamp = (value) => {
-            const date = this.parseLocalDate(value);
-            if (!date) {
-                return Number.MAX_SAFE_INTEGER;
-            }
-
-            const normalized = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-            return normalized.getTime();
-
-
-
-            if (!value) {
-                return Number.MAX_SAFE_INTEGER;
-            }
-            const timestamp = Date.parse(value);
-            return Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp;
-
-
-        };
-
-        const result = Array.from(groups.values()).map((group) => ({
-            ...group,
-            cities: Array.from(group.cities),
-            deliveryDates: Array.from(group.deliveryDates),
-            acceptTimes: Array.from(group.acceptTimes),
-            statuses: Array.from(group.statuses)
-        }));
-
-        result.sort((a, b) => {
-            const timeA = toTimestamp(a.departureDate || '');
-            const timeB = toTimestamp(b.departureDate || '');
-            if (timeA !== timeB) {
-                return timeA - timeB;
-            }
-
-            return String(a.key).localeCompare(String(b.key), 'ru');
-        });
-
-        return result;
-    }
-
-    getGroupStatusInfo(group) {
-        const statuses = Array.isArray(group?.statuses) ? group.statuses.filter(Boolean) : [];
-        if (statuses.length === 0) {
-            return {
-                text: '—',
-                className: this.getStatusClass('')
-            };
-        }
-
-        const priority = ['Приём заявок', 'Ожидает отправки', 'В пути', 'Завершено'];
-        const sorted = statuses.slice().sort((a, b) => {
-            const indexA = priority.indexOf(a);
-            const indexB = priority.indexOf(b);
-            const safeA = indexA === -1 ? priority.length : indexA;
-            const safeB = indexB === -1 ? priority.length : indexB;
-            if (safeA !== safeB) {
-                return safeA - safeB;
-            }
-            return a.localeCompare(b, 'ru');
-        });
-
-        const text = sorted[0];
-        return {
-            text,
-            className: this.getStatusClass(text)
-        };
-    }
-
-    formatCityCount(count) {
-        const safeCount = Number.isFinite(Number(count)) ? Number(count) : 0;
-        if (safeCount <= 0) {
-            return 'Город будет выбран при оформлении';
-        }
-
-        if (safeCount === 1) {
-            return 'Доступен 1 город';
-        }
-
-        if (safeCount >= 5) {
-            return `Доступно ${safeCount} городов`;
-        }
-
-        return `Доступно ${safeCount} города`;
-    }
-
-    createExtraSectionId(groupIdentifier, scheduleId, index = 0) {
-        const parts = [];
-
-        if (groupIdentifier) {
-            parts.push(groupIdentifier);
-        }
-
-        if (scheduleId) {
-            parts.push(scheduleId);
-        }
-
-        parts.push(index);
-
-        const base = parts
-            .map((part) => String(part))
-            .join('-')
-            .replace(/[^a-zA-Z0-9_-]+/g, '-')
-            .replace(/-{2,}/g, '-')
-            .replace(/^-|-$/g, '');
-
-        return `schedule-extra-${base || `group-${index}`}`;
-    }
-
-    formatDeliverySummary(group) {
-        const dates = Array.isArray(group?.deliveryDates) ? group.deliveryDates : [];
-        if (dates.length === 0) {
-            return '—';
-        }
-
-        const formatted = dates
-            .map(date => this.formatDate(date))
-            .filter(Boolean);
-
-        if (formatted.length === 0) {
-            return '—';
-        }
-
-        if (formatted.length === 1) {
-            return formatted[0];
-        }
-
-        return `${formatted[0]} и ещё ${formatted.length - 1}`;
-    }
-
-    formatAcceptTimeInfo(group) {
-        const times = Array.isArray(group?.acceptTimes) ? group.acceptTimes.filter(Boolean) : [];
-        if (times.length === 0) {
-            return '—';
-        }
-
-        if (times.length === 1) {
-            return times[0];
-        }
-
-        return `${times.length} вариантов`;
-    }
-
-    normalizeWarehouseStatsResponse(data) {
-        const ordersTotal = this.toNumber(data?.orders_total);
-        const ordersForWarehouse = this.toNumber(data?.orders_for_warehouse);
-        let ordersPercentage = Number(data?.orders_percentage);
-        if (!Number.isFinite(ordersPercentage)) {
-            ordersPercentage = ordersTotal > 0
-                ? (ordersForWarehouse / ordersTotal) * 100
-                : 0;
-        }
-
-        ordersPercentage = Math.min(Math.max(ordersPercentage, 0), 100);
-
-        return {
-            marketplace: data?.marketplace || this.filters.marketplace || '',
-            warehouse: data?.warehouse || this.filters.warehouse || '',
-            ordersTotal,
-            ordersForWarehouse,
-            ordersPercentage
-        };
-    }
-
-    toNumber(value) {
-        const numeric = Number(value);
-        return Number.isFinite(numeric) ? numeric : 0;
-    }
-
-    formatNumber(value, options = {}) {
-        const numeric = Number(value);
-        const safeValue = Number.isFinite(numeric) ? numeric : 0;
-        const { maximumFractionDigits = 0 } = options;
-        return new Intl.NumberFormat('ru-RU', {
-            minimumFractionDigits: 0,
-            maximumFractionDigits
-        }).format(safeValue);
-    }
-
-    formatPercentage(value) {
-        const numeric = Number(value);
-        const safeValue = Number.isFinite(numeric) ? numeric : 0;
-        return new Intl.NumberFormat('ru-RU', {
-            minimumFractionDigits: safeValue > 0 && safeValue < 1 ? 1 : 0,
-            maximumFractionDigits: safeValue > 0 ? 1 : 0
-        }).format(safeValue);
-    }
-
-    async loadSchedules() {
-        if (!this.filters.marketplace || !this.filters.warehouse) {
-            this.applyFilters();
-            return;
-        }
-
-        const cacheKey = `${this.filters.marketplace}__${this.filters.warehouse}`;
-        if (this.schedulesCache.has(cacheKey)) {
-            this.schedules = this.schedulesCache.get(cacheKey);
-            this.applyFilters();
-            return;
-        }
-
-        this.isLoadingSchedules = true;
-        this.renderScheduleGrid();
-        this.renderWarehouseStats();
-
-        try {
-            const params = new URLSearchParams({
-                marketplace: this.filters.marketplace,
-                warehouse: this.filters.warehouse
-            });
-
-            const response = await fetch(`../fetch_schedule.php?${params.toString()}`, {
-                credentials: 'include'
-            });
-
-            if (!response.ok) {
-                throw new Error('Network response was not ok');
-            }
-
-            const data = await response.json();
-            this.schedules = Array.isArray(data) ? data : [];
-            this.schedulesCache.set(cacheKey, this.schedules);
-        } catch (error) {
             console.error('Ошибка загрузки расписания:', error);
-            this.showError('Не удалось загрузить расписание');
-            this.schedules = [];
+            this.errorMessage = 'Не удалось загрузить расписание. Попробуйте позже.';
+            this.originalSchedules = [];
+            this.enrichedSchedules = [];
+            this.scheduleLookup.clear();
+
+            if (window.app && typeof window.app.showError === 'function') {
+                window.app.showError('Не удалось загрузить расписание');
+            }
         } finally {
-            this.isLoadingSchedules = false;
-            this.applyFilters();
+            if (this.activeRequestController === controller) {
+                this.activeRequestController = null;
+            }
+
+            this.isLoading = false;
+            this.renderWeek();
         }
     }
 
-    applyFilters() {
-        if (!this.filters.marketplace || !this.filters.warehouse) {
-            this.filteredSchedules = [];
-            this.groupedSchedules = [];
-            this.scheduleGroupsByKey.clear();
-            this.renderScheduleGrid();
-            this.renderWarehouseStats();
-            return;
+    async fetchSchedules(signal) {
+        const params = new URLSearchParams();
+        if (this.state.marketplace) {
+            params.set('marketplace', this.state.marketplace);
+        }
+        if (this.state.city) {
+            params.set('city', this.state.city);
         }
 
-        this.filteredSchedules = this.schedules.filter((schedule) => {
-            if (!schedule) {
-                return false;
-            }
-
-            const matchMarketplace = schedule.marketplace === this.filters.marketplace;
-            const matchWarehouse = schedule.warehouses === this.filters.warehouse;
-
-            if (!matchMarketplace || !matchWarehouse) {
-                return false;
-            }
-
-            return this.isScheduleInFuture(schedule);
+        const query = params.toString();
+        const response = await fetch(`../fetch_schedule.php${query ? `?${query}` : ''}`, {
+            credentials: 'include',
+            signal
         });
 
-        this.groupedSchedules = this.groupSchedulesByDate(this.filteredSchedules);
-        this.scheduleGroupsByKey = new Map(
-            this.groupedSchedules.map(group => [group.key, group])
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+
+        const contentType = (response.headers.get('content-type') || '').toLowerCase();
+        if (contentType.includes('application/json')) {
+            const payload = await response.json();
+            return Array.isArray(payload) ? payload : [];
+        }
+
+        const textPayload = await response.text();
+        try {
+            const parsed = JSON.parse(textPayload);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (parseError) {
+            throw new Error('Некорректный формат ответа сервера');
+        }
+    }
+
+    updateSchedules(schedules) {
+        this.originalSchedules = Array.isArray(schedules) ? schedules : [];
+        this.enrichedSchedules = this.prepareSchedules(this.originalSchedules);
+        this.scheduleLookup = new Map(
+            this.enrichedSchedules.map((entry) => [entry.id, entry])
         );
-
-        this.renderScheduleGrid();
-        this.renderWarehouseStats();
     }
 
-    renderScheduleGrid() {
-        const container = document.getElementById('scheduleGrid');
-        if (!container) return;
+    prepareSchedules(schedules) {
+        if (!Array.isArray(schedules)) {
+            return [];
+        }
 
-        if (this.scheduleGridElement !== container) {
-            if (this.scheduleGridElement) {
-                this.scheduleGridElement.removeEventListener('click', this.boundHandleScheduleGridClick);
+        return schedules
+            .map((schedule, index) => {
+                const details = this.normalizeSchedule(schedule);
+                const acceptDate = this.parseDate(details.acceptDate);
+                const id = this.computeScheduleId(schedule, index);
+                const dateKey = acceptDate ? this.formatDateKey(acceptDate) : '';
+                return {
+                    id,
+                    raw: schedule,
+                    details,
+                    acceptDate,
+                    dateKey,
+                    timeValue: this.parseTime(details.acceptTime)
+                };
+            })
+            .filter((entry) => Boolean(entry.dateKey));
+    }
+
+    computeScheduleId(schedule, index) {
+        const candidates = ['id', 'schedule_id', 'scheduleId'];
+        for (const key of candidates) {
+            const value = schedule && schedule[key];
+            if (value === undefined || value === null) {
+                continue;
             }
-            container.addEventListener('click', this.boundHandleScheduleGridClick);
-            this.scheduleGridElement = container;
-        }
-
-        container.classList.remove('is-empty');
-
-        if (!this.filters.marketplace) {
-            this.updateScheduleSubtitle('Чтобы увидеть расписание, выберите маркетплейс и склад');
-            container.classList.add('is-empty');
-            container.innerHTML = this.renderEmptyState(
-                'fa-layer-group',
-                'Расписание недоступно',
-                'Укажите маркетплейс и склад, чтобы мы показали подходящие отправления.'
-            );
-            return;
-        }
-
-        if (!this.filters.warehouse) {
-            this.updateScheduleSubtitle('Сначала выберите склад, чтобы увидеть доступные отправления');
-            container.classList.add('is-empty');
-            container.innerHTML = this.renderEmptyState(
-                'fa-warehouse',
-                'Не выбран склад',
-                'Выберите склад, чтобы показать подходящее расписание.'
-            );
-            return;
-        }
-
-        if (this.isLoadingSchedules) {
-            this.updateScheduleSubtitle(`Загружаем расписание для склада «${this.filters.warehouse}»...`);
-            container.classList.add('is-empty');
-            container.innerHTML = `
-                <div class="loading">
-                    <div class="spinner"></div>
-                    Подгружаем отправления...
-                </div>
-            `;
-            return;
-        }
-
-        if (!Array.isArray(this.groupedSchedules) || this.groupedSchedules.length === 0) {
-            this.updateScheduleSubtitle('На выбранный склад пока нет активных отправлений');
-            container.classList.add('is-empty');
-            container.innerHTML = this.renderEmptyState(
-                'fa-calendar-times',
-                'Нет доступных отправлений',
-                'Попробуйте выбрать другой склад или загляните позже.'
-            );
-            return;
-        }
-
-        this.updateScheduleSubtitle(`Доступные даты отправления: ${this.groupedSchedules.length}`);
-        container.innerHTML = this.groupedSchedules
-            .map((group, index) => this.renderScheduleCard(group, index))
-            .join('');
-    }
-
-    renderScheduleCard(group, index = 0) {
-    const baseDetails = Array.isArray(group?.scheduleDetails) && group.scheduleDetails.length > 0
-        ? group.scheduleDetails[0]
-        : this.normalizeScheduleForModal(null);
-
-    const marketplaceLabel = baseDetails.marketplace || this.filters.marketplace || '';
-    const marketplace = this.escapeHtml(marketplaceLabel || '—');
-    const marketplaceClass = this.getMarketplaceBadgeClass(marketplaceLabel);
-
-    const warehouseName = baseDetails.warehouse || baseDetails.warehouses || this.filters.warehouse || '';
-    const warehouse = this.escapeHtml(warehouseName || '—');
-
-    const departureDate = this.escapeHtml(
-        this.formatDate(group?.departureDate || baseDetails.accept_date || baseDetails.acceptDate)
-    );
-    const deliveryDate = this.escapeHtml(this.formatDeliverySummary(group));
-    const acceptTime = this.escapeHtml(this.formatAcceptTimeInfo(group));
-
-    const driver = this.escapeHtml(baseDetails.driver_name || baseDetails.driverName || '—');
-    const carInfo = this.escapeHtml(
-        [baseDetails.car_brand || baseDetails.carBrand, baseDetails.car_number || baseDetails.carNumber]
-            .filter(Boolean).join(' ') || '—'
-    );
-
-    const statusInfo = this.getGroupStatusInfo(group) || {};
-    const statusText = this.escapeHtml(statusInfo.text || '—');
-    const statusClass = statusInfo.className || 'default';
-
-    const citiesCount = Array.isArray(group?.cities) ? group.cities.length : 0;
-    const citiesSummary = this.escapeHtml(this.formatCityCount(citiesCount));
-
-    const groupIdentifier = group?.key ?? '';
-    const primaryScheduleId = group?.primaryScheduleId ?? baseDetails.id ?? '';
-
-    const safeGroupIdentifier = this.escapeHtml(String(groupIdentifier || ''));
-    const safeScheduleId = this.escapeHtml(String(primaryScheduleId || ''));
-
-    const extraSectionId = this.escapeHtml(
-        this.createExtraSectionId(groupIdentifier, primaryScheduleId, index)
-    );
-    const ariaControlsAttribute = extraSectionId ? ` aria-controls="${extraSectionId}"` : '';
-
-    return `
-        <article class="schedule-card" data-group="${safeGroupIdentifier}">
-            <div class="schedule-status-indicator status-${statusClass}"></div>
-            <div class="schedule-card-body">
-                <div class="schedule-card-main">
-                    <header class="schedule-card-header">
-                        <span class="schedule-card-warehouse">${warehouse}</span>
-                        <span class="schedule-marketplace ${marketplaceClass}">${marketplace}</span>
-                    </header>
-
-                    <div class="schedule-card-dates">
-                        <div class="schedule-dates-header">
-                            <span class="schedule-dates-label schedule-dates-label--departure">ВЫЕЗД:</span>
-                            <i class="fas fa-truck schedule-dates-icon" aria-hidden="true"></i>
-                            <span class="schedule-dates-label schedule-dates-label--delivery">СДАЧА:</span>
-                        </div>
-
-                        <div class="schedule-dates-values">
-                            <span class="date-value date-value--departure">${departureDate || '—'}</span>
-                            <span class="date-value date-value--delivery">${deliveryDate}</span>
-                        </div>
-                    </div>
-
-                    <div class="schedule-action">
-                        <button
-                            type="button"
-                            class="create-order-btn"
-                            data-group-key="${safeGroupIdentifier}"
-                            data-schedule-id="${safeScheduleId}"
-                        >
-                            <i class="fas fa-plus"></i>
-                            Создать заявку
-                        </button>
-                    </div>
-                </div>
-
-                <div class="schedule-card-extra" id="${extraSectionId}" aria-hidden="true">
-                    <div class="schedule-status status-${statusClass}">
-                        <span class="status-dot"></span>
-                        ${statusText}
-                    </div>
-
-                    <div class="schedule-meta">
-                        <div class="meta-item">
-                            <span class="meta-label">Время приёмки</span>
-                            <span class="meta-value">${acceptTime}</span>
-                        </div>
-                        <div class="meta-item">
-                            <span class="meta-label">Водитель</span>
-                            <span class="meta-value">${driver}</span>
-                        </div>
-                        <div class="meta-item">
-                            <span class="meta-label">Автомобиль</span>
-                            <span class="meta-value">${carInfo}</span>
-                        </div>
-                        <div class="meta-item">
-                            <span class="meta-label">Города</span>
-                            <span class="meta-value">${citiesSummary}</span>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="schedule-card-footer">
-                    <button
-                        type="button"
-                        class="schedule-card-toggle"
-                        data-toggle-group="${safeGroupIdentifier}"
-                        aria-expanded="false"${ariaControlsAttribute}
-                    >
-                        <span class="toggle-label">Развернуть</span>
-                        <i class="fas fa-chevron-down toggle-icon" aria-hidden="true"></i>
-                    </button>
-                </div>
-            </div>
-        </article>
-    `;
-}
-
-
-
-    handleScheduleGridClick(event) {
-        if (!event || !(event.target instanceof HTMLElement)) {
-            return;
-        }
-
-        const button = event.target.closest('.create-order-btn');
-        if (!button || button.disabled) {
-            return;
-        }
-
-        const currentTarget = event.currentTarget;
-        if (currentTarget instanceof HTMLElement && !currentTarget.contains(button)) {
-            return;
-        }
-
-        event.preventDefault();
-        const { groupKey = '', scheduleId = '' } = button.dataset || {};
-        const identifier = groupKey || scheduleId;
-
-        this.handleCreateOrderClick(event, identifier, button);
-    }
-
-    handleCreateOrderClick(event, scheduleId, explicitButton) {
-        const button = explicitButton instanceof HTMLElement
-            ? explicitButton
-            : event?.target instanceof HTMLElement
-                ? event.target.closest('.create-order-btn')
-                : event?.currentTarget instanceof HTMLElement && event.currentTarget.classList.contains('create-order-btn')
-                    ? event.currentTarget
-                    : null;
-
-        this.animateActionButton(button);
-
-        let potentialGroupKey = '';
-        if (typeof scheduleId === 'string' || typeof scheduleId === 'number') {
-            potentialGroupKey = String(scheduleId);
-        }
-
-        if (!potentialGroupKey && button?.dataset?.groupKey) {
-            potentialGroupKey = button.dataset.groupKey;
-        }
-
-        if (potentialGroupKey && this.scheduleGroupsByKey.has(potentialGroupKey)) {
-            this.createOrderForScheduleGroup(potentialGroupKey);
-            return;
-
-        }
-
-        let fallbackScheduleId = '';
-        if (button?.dataset?.scheduleId) {
-            fallbackScheduleId = button.dataset.scheduleId;
-        }
-
-        if (!fallbackScheduleId && (typeof scheduleId === 'string' || typeof scheduleId === 'number')) {
-            fallbackScheduleId = String(scheduleId);
-        } else if (!fallbackScheduleId && scheduleId && typeof scheduleId === 'object' && 'id' in scheduleId) {
-            fallbackScheduleId = String(scheduleId.id);
-        }
-
-        if (fallbackScheduleId) {
-            this.createOrderForSchedule(fallbackScheduleId);
-        }
-    }
-
-    handleScheduleGridClick(event) {
-        if (!event || !(event.target instanceof HTMLElement)) {
-            return;
-        }
-
-        const toggleButton = event.target.closest('.schedule-card-toggle');
-        if (toggleButton) {
-            const card = toggleButton.closest('.schedule-card');
-            if (card) {
-                event.preventDefault();
-                this.toggleScheduleCardExpansion(card, toggleButton);
-            }
-            return;
-        }
-
-        const button = event.target.closest('.create-order-btn');
-        if (!button || button.disabled) {
-            return;
-        }
-
-        const currentTarget = event.currentTarget;
-        if (currentTarget instanceof HTMLElement && !currentTarget.contains(button)) {
-            return;
-        }
-
-        event.preventDefault();
-        const { groupKey = '', scheduleId = '' } = button.dataset || {};
-        const identifier = groupKey || scheduleId;
-
-        this.handleCreateOrderClick(event, identifier, button);
-    }
-
-    toggleScheduleCardExpansion(card, explicitButton) {
-        if (!(card instanceof HTMLElement)) {
-            return;
-        }
-
-        const shouldExpand = !card.classList.contains('is-expanded');
-        card.classList.toggle('is-expanded', shouldExpand);
-
-        const button = explicitButton instanceof HTMLElement
-            ? explicitButton
-            : card.querySelector('.schedule-card-toggle');
-
-        const extraSection = card.querySelector('.schedule-card-extra');
-        if (extraSection instanceof HTMLElement) {
-            extraSection.setAttribute('aria-hidden', shouldExpand ? 'false' : 'true');
-        }
-
-        if (button) {
-            button.setAttribute('aria-expanded', shouldExpand ? 'true' : 'false');
-            const label = button.querySelector('.toggle-label');
-            if (label) {
-                label.textContent = shouldExpand ? 'Свернуть' : 'Развернуть';
-            }
-
-            const icon = button.querySelector('.toggle-icon');
-            if (icon) {
-                icon.classList.remove('fa-chevron-down', 'fa-chevron-up');
-                icon.classList.add(shouldExpand ? 'fa-chevron-up' : 'fa-chevron-down');
+            const str = String(value).trim();
+            if (str) {
+                return str;
             }
         }
+
+        return `schedule_${Date.now()}_${index}_${Math.random().toString(36).slice(2, 7)}`;
     }
 
-handleCreateOrderClick(event, scheduleId, explicitButton) {
-    // 1) Находим кнопку
-    const button =
-        explicitButton instanceof HTMLElement
-            ? explicitButton
-            : (event?.target instanceof HTMLElement
-                ? event.target.closest('.create-order-btn')
-                : (event?.currentTarget instanceof HTMLElement &&
-                   event.currentTarget.classList.contains('create-order-btn')
-                        ? event.currentTarget
-                        : null));
-
-    // 2) Анимация кнопки (если нашли)
-    if (button) {
-        this.animateActionButton(button);
-    }
-
-    // 3) Сначала пытаемся трактовать scheduleId как groupKey (для групповых)
-    let potentialGroupKey = '';
-    if (typeof scheduleId === 'string' || typeof scheduleId === 'number') {
-        potentialGroupKey = String(scheduleId);
-    }
-    if (!potentialGroupKey && button?.dataset?.groupKey) {
-        potentialGroupKey = button.dataset.groupKey;
-    }
-
-    if (potentialGroupKey && this.scheduleGroupsByKey?.has?.(potentialGroupKey)) {
-        this.createOrderForScheduleGroup(potentialGroupKey);
-        return;
-    }
-
-    // 4) Иначе — обычный scheduleId
-    let finalScheduleId = '';
-    if (button?.dataset?.scheduleId) {
-        finalScheduleId = button.dataset.scheduleId;
-    }
-    if (!finalScheduleId) {
-        if (typeof scheduleId === 'string' || typeof scheduleId === 'number') {
-            finalScheduleId = String(scheduleId);
-        } else if (scheduleId && typeof scheduleId === 'object' && 'id' in scheduleId) {
-            finalScheduleId = String(scheduleId.id);
-        }
-    }
-
-    if (finalScheduleId) {
-        this.createOrderForSchedule(finalScheduleId);
-    } else {
-        console.warn('handleCreateOrderClick: не удалось определить scheduleId', { event, scheduleId, button });
-    }
-} // ← ЭТО важная закрывающая скобка функции!
-
-animateActionButton(button) {
-    if (!(button instanceof HTMLElement)) return;
-
-    button.classList.remove('is-pressed');
-    // Перезапуск анимации, если кликают повторно
-    void button.offsetWidth;
-    button.classList.add('is-pressed');
-
-    button.addEventListener('animationend', () => {
-        button.classList.remove('is-pressed');
-    }, { once: true });
-}
-
-
-    getMarketplaceBadgeClass(marketplace) {
-        if (!marketplace) {
+    normalizeSchedule(schedule) {
+        const getValue = (keys) => {
+            for (const key of keys) {
+                if (!key || !schedule || !(key in schedule)) {
+                    continue;
+                }
+                const raw = schedule[key];
+                if (raw === undefined || raw === null) {
+                    continue;
+                }
+                if (typeof raw === 'string') {
+                    const trimmed = raw.trim();
+                    if (trimmed) {
+                        return trimmed;
+                    }
+                } else if (typeof raw === 'number') {
+                    return String(raw);
+                }
+            }
             return '';
-        }
-
-        const normalized = marketplace.toLowerCase();
-        if (normalized.includes('wildberries')) {
-            return 'marketplace-wb';
-        }
-        if (normalized.includes('ozon')) {
-            return 'marketplace-ozon';
-        }
-        if (normalized.includes('yandex')) {
-            return 'marketplace-yandex';
-        }
-        return '';
-    }
-
-    renderEmptyState(icon, title, description) {
-        const safeIcon = this.escapeHtml(icon);
-        const safeTitle = this.escapeHtml(title);
-        const safeDescription = this.escapeHtml(description);
-        return `
-            <div class="empty-state">
-                <i class="fas ${safeIcon}"></i>
-                <h3>${safeTitle}</h3>
-                <p>${safeDescription}</p>
-            </div>
-        `;
-    }
-
-    escapeHtml(value) {
-        if (value === null || value === undefined) {
-            return '';
-        }
-
-        return String(value)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#039;');
-    }
-
-    getStatusClass(status) {
-        const statusMap = {
-            'Приём заявок': 'open',
-            'Ожидает отправки': 'waiting',
-            'В пути': 'transit',
-            'Завершено': 'completed'
         };
-        return statusMap[status] || 'unknown';
+
+        return {
+            id: getValue(['id', 'schedule_id', 'scheduleId']),
+            marketplace: getValue(['marketplace']),
+            city: getValue(['city', 'city_name', 'route_city']),
+            warehouse: getValue(['warehouses', 'warehouse', 'route_warehouse']),
+            acceptDate: getValue(['accept_date', 'acceptDate', 'departure_date', 'departureDate']),
+            deliveryDate: getValue(['delivery_date', 'deliveryDate']),
+            acceptTime: getValue(['accept_time', 'acceptTime']),
+            status: getValue(['status']),
+            driverName: getValue(['driver_name', 'driverName']),
+            driverPhone: getValue(['driver_phone', 'driverPhone']),
+            carNumber: getValue(['car_number', 'carNumber']),
+            carBrand: getValue(['car_brand', 'carBrand']),
+            sender: getValue(['sender', 'company_name'])
+        };
     }
 
-    formatDate(dateStr) {
-        const date = this.parseLocalDate(dateStr);
+    parseDate(value) {
+        if (!value) {
+            return null;
+        }
+
+        if (value instanceof Date) {
+            return new Date(value.getTime());
+        }
+
+        if (typeof value === 'number') {
+            const dateFromNumber = new Date(value);
+            return Number.isNaN(dateFromNumber.getTime()) ? null : dateFromNumber;
+        }
+
+        const stringValue = String(value).trim();
+        if (!stringValue) {
+            return null;
+        }
+
+        const dotMatch = stringValue.match(/^(\d{2})\.(\d{2})\.(\d{4})/);
+        if (dotMatch) {
+            const [, day, month, year] = dotMatch;
+            const parsed = new Date(Number(year), Number(month) - 1, Number(day));
+            return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+
+        const normalized = stringValue.includes('T') ? stringValue : stringValue.replace(' ', 'T');
+        const isoCandidate = normalized.length <= 10 ? `${normalized}T00:00:00` : normalized;
+        const date = new Date(isoCandidate);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    parseTime(value) {
+        if (!value) {
+            return Number.POSITIVE_INFINITY;
+        }
+
+        const match = String(value).match(/(\d{1,2}):(\d{2})/);
+        if (!match) {
+            return Number.POSITIVE_INFINITY;
+        }
+
+        const hours = Number(match[1]);
+        const minutes = Number(match[2]);
+        if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+            return Number.POSITIVE_INFINITY;
+        }
+
+        return hours * 60 + minutes;
+    }
+
+    formatDateKey(date) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+    }
+
+    formatDate(value) {
+        const date = this.parseDate(value);
         if (!date) {
             return '—';
         }
@@ -2019,138 +522,427 @@ animateActionButton(button) {
         });
     }
 
-    createOrderForSchedule(scheduleId) {
-        const schedule = this.schedules.find(s => String(s.id) === String(scheduleId));
-        if (!schedule) return;
+    formatShortDate(date) {
+        return date.toLocaleDateString('ru-RU', {
+            day: '2-digit',
+            month: '2-digit'
+        });
+    }
 
+    formatWeekday(date) {
+        const raw = date.toLocaleDateString('ru-RU', { weekday: 'long' });
+        return raw.charAt(0).toUpperCase() + raw.slice(1);
+    }
+
+    getWeekDays() {
+        const days = [];
+        for (let index = 0; index < 6; index += 1) {
+            const day = new Date(this.state.weekStart);
+            day.setDate(day.getDate() + index);
+            days.push(day);
+        }
+        return days;
+    }
+
+    getSchedulesForDay(dateKey) {
+        return this.enrichedSchedules
+            .filter((entry) => entry.dateKey === dateKey)
+            .sort((a, b) => {
+                if (a.timeValue !== b.timeValue) {
+                    return a.timeValue - b.timeValue;
+                }
+
+                const first = a.details.warehouse || '';
+                const second = b.details.warehouse || '';
+                return first.localeCompare(second, 'ru', { sensitivity: 'base' });
+            });
+    }
+
+    renderWeekRange() {
+        const range = this.elements.range;
+        if (!range) {
+            return;
+        }
+
+        const start = this.state.weekStart;
+        const end = new Date(this.state.weekStart);
+        end.setDate(end.getDate() + 5);
+        range.textContent = `${this.formatShortDate(start)} – ${this.formatShortDate(end)}`;
+    }
+
+    renderWeek() {
+        this.renderWeekRange();
+
+        if (!this.elements.grid) {
+            return;
+        }
+
+        if (this.isLoading) {
+            this.renderLoadingState();
+            return;
+        }
+
+        if (this.errorMessage) {
+            this.renderErrorState(this.errorMessage);
+            return;
+        }
+
+        this.renderTimeline();
+    }
+
+    renderLoadingState() {
+        const grid = this.elements.grid;
+        if (!grid) {
+            return;
+        }
+
+        const container = document.createElement('div');
+        container.className = 'schedule-loading';
+
+        const spinner = document.createElement('div');
+        spinner.className = 'schedule-spinner';
+        container.appendChild(spinner);
+
+        const text = document.createElement('span');
+        text.textContent = 'Загружаем расписание...';
+        container.appendChild(text);
+
+        grid.innerHTML = '';
+        grid.appendChild(container);
+    }
+
+    renderErrorState(message) {
+        const grid = this.elements.grid;
+        if (!grid) {
+            return;
+        }
+
+        const container = document.createElement('div');
+        container.className = 'schedule-empty';
+
+        const icon = document.createElement('i');
+        icon.className = 'fas fa-exclamation-circle';
+        container.appendChild(icon);
+
+        const title = document.createElement('h3');
+        title.textContent = 'Ошибка загрузки';
+        container.appendChild(title);
+
+        const description = document.createElement('p');
+        description.textContent = message;
+        container.appendChild(description);
+
+        grid.innerHTML = '';
+        grid.appendChild(container);
+    }
+
+    renderTimeline() {
+        const grid = this.elements.grid;
+        if (!grid) {
+            return;
+        }
+
+        const days = this.getWeekDays();
+        const fragment = document.createDocumentFragment();
+
+        days.forEach((day) => {
+            fragment.appendChild(this.createDayColumn(day));
+        });
+
+        grid.innerHTML = '';
+        grid.appendChild(fragment);
+    }
+
+    createDayColumn(date) {
+        const wrapper = document.createElement('article');
+        wrapper.className = 'schedule-day';
+
+        const header = document.createElement('header');
+        header.className = 'schedule-day__header';
+
+        const weekday = document.createElement('span');
+        weekday.className = 'schedule-day__weekday';
+        weekday.textContent = this.formatWeekday(date);
+        header.appendChild(weekday);
+
+        const dateLabel = document.createElement('span');
+        dateLabel.className = 'schedule-day__date';
+        dateLabel.textContent = date.toLocaleDateString('ru-RU', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric'
+        });
+        header.appendChild(dateLabel);
+
+        wrapper.appendChild(header);
+
+        const list = document.createElement('div');
+        list.className = 'schedule-day__list';
+
+        const dateKey = this.formatDateKey(date);
+        const schedules = this.getSchedulesForDay(dateKey);
+
+        if (schedules.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'schedule-day__empty';
+            empty.textContent = 'Нет отправлений';
+            list.appendChild(empty);
+        } else {
+            schedules.forEach((entry) => {
+                list.appendChild(this.createShipmentElement(entry));
+            });
+        }
+
+        wrapper.appendChild(list);
+        return wrapper;
+    }
+
+    createShipmentElement(entry) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'schedule-shipment';
+        button.dataset.scheduleId = entry.id;
+
+        const { details } = entry;
+
+        const header = document.createElement('div');
+        header.className = 'schedule-shipment__header';
+
+        const destination = document.createElement('span');
+        destination.className = 'schedule-shipment__destination';
+        destination.textContent = details.warehouse || 'Склад не указан';
+        header.appendChild(destination);
+
+        const badgeText = this.getMarketplaceBadge(details.marketplace);
+        if (badgeText) {
+            const badge = document.createElement('span');
+            const badgeClass = this.getMarketplaceBadgeClass(details.marketplace);
+            badge.className = `schedule-shipment__badge${badgeClass ? ` ${badgeClass}` : ''}`;
+            badge.textContent = badgeText;
+            header.appendChild(badge);
+        }
+
+        button.appendChild(header);
+
+        if (details.city) {
+            const route = document.createElement('div');
+            route.className = 'schedule-shipment__route';
+            route.textContent = `${details.city} → ${details.warehouse || '—'}`;
+            button.appendChild(route);
+        }
+
+        const meta = document.createElement('div');
+        meta.className = 'schedule-shipment__meta';
+
+        if (details.status) {
+            const status = document.createElement('span');
+            const statusClass = this.getStatusClass(details.status);
+            status.className = `schedule-shipment__status${statusClass ? ` ${statusClass}` : ''}`;
+            status.textContent = details.status;
+            meta.appendChild(status);
+        }
+
+        if (details.acceptTime) {
+            const accept = document.createElement('span');
+            accept.className = 'schedule-shipment__chip';
+            accept.textContent = `Приём: ${details.acceptTime}`;
+            meta.appendChild(accept);
+        }
+
+        if (details.deliveryDate) {
+            const delivery = document.createElement('span');
+            delivery.className = 'schedule-shipment__chip';
+            delivery.textContent = `Сдача: ${this.formatDate(details.deliveryDate)}`;
+            meta.appendChild(delivery);
+        }
+
+        if (meta.childNodes.length > 0) {
+            button.appendChild(meta);
+        }
+
+        const footer = document.createElement('div');
+        footer.className = 'schedule-shipment__footer';
+
+        const action = document.createElement('span');
+        action.className = 'schedule-shipment__action';
+        action.textContent = 'Оформить заявку';
+        footer.appendChild(action);
+
+        button.appendChild(footer);
+        return button;
+    }
+
+    getMarketplaceBadge(marketplace) {
+        if (!marketplace) {
+            return '';
+        }
+
+        const normalized = marketplace.toLowerCase();
+        if (normalized.includes('wildberries')) {
+            return 'WB';
+        }
+        if (normalized.includes('ozon')) {
+            return 'OZ';
+        }
+        if (normalized.includes('yandex') || normalized.includes('market')) {
+            return 'YM';
+        }
+        return marketplace.length > 3 ? marketplace.slice(0, 3).toUpperCase() : marketplace;
+    }
+
+    getMarketplaceBadgeClass(marketplace) {
+        if (!marketplace) {
+            return '';
+        }
+
+        const normalized = marketplace.toLowerCase();
+        if (normalized.includes('wildberries')) {
+            return 'badge-wb';
+        }
+        if (normalized.includes('ozon')) {
+            return 'badge-ozon';
+        }
+        if (normalized.includes('yandex') || normalized.includes('market')) {
+            return 'badge-ym';
+        }
+        return '';
+    }
+
+    getStatusClass(status) {
+        if (!status) {
+            return 'status-unknown';
+        }
+
+        const map = new Map([
+            ['приём заявок', 'status-open'],
+            ['ожидает отправки', 'status-waiting'],
+            ['в пути', 'status-transit'],
+            ['завершено', 'status-completed']
+        ]);
+
+        const normalized = status.toLowerCase();
+        return map.get(normalized) || 'status-unknown';
+    }
+
+    openScheduleDetails(entry) {
+        const modal = document.getElementById('scheduleDetailsModal');
+        const content = document.getElementById('scheduleDetailsContent');
+
+        if (!modal || !content) {
+            this.createOrder(entry.raw);
+            return;
+        }
+
+        content.innerHTML = '';
+
+        const container = document.createElement('div');
+        container.className = 'schedule-modal';
+
+        const grid = document.createElement('div');
+        grid.className = 'schedule-modal__grid';
+
+        const pushItem = (label, value) => {
+            if (!value || String(value).trim().length === 0) {
+                return;
+            }
+            const item = document.createElement('div');
+            item.className = 'schedule-modal__item';
+
+            const title = document.createElement('span');
+            title.className = 'schedule-modal__label';
+            title.textContent = label;
+            item.appendChild(title);
+
+            const val = document.createElement('span');
+            val.className = 'schedule-modal__value';
+            val.textContent = value;
+            item.appendChild(val);
+
+            grid.appendChild(item);
+        };
+
+        const { details } = entry;
+
+        pushItem('Маркетплейс', details.marketplace);
+        pushItem('Город отправления', details.city);
+        pushItem('Склад/направление', details.warehouse);
+        pushItem('Дата отправления', this.formatDate(details.acceptDate));
+        pushItem('Время приёма', details.acceptTime);
+        pushItem('Сдача на склад', this.formatDate(details.deliveryDate));
+        pushItem('Статус', details.status);
+        pushItem('Водитель', details.driverName);
+        pushItem('Телефон водителя', details.driverPhone);
+        pushItem('Транспорт', [details.carBrand, details.carNumber].filter(Boolean).join(' ').trim());
+        pushItem('Отправитель', details.sender);
+
+        container.appendChild(grid);
+
+        const actions = document.createElement('div');
+        actions.className = 'schedule-modal__actions';
+
+        const createOrderBtn = document.createElement('button');
+        createOrderBtn.type = 'button';
+        createOrderBtn.className = 'create-order-btn';
+        createOrderBtn.textContent = 'Создать заявку';
+        createOrderBtn.addEventListener('click', () => {
+            this.createOrder(entry.raw);
+        });
+
+        actions.appendChild(createOrderBtn);
+        container.appendChild(actions);
+
+        content.appendChild(container);
+
+        if (window.app && typeof window.app.openModal === 'function') {
+            window.app.openModal(modal);
+        } else {
+            modal.classList.add('active');
+        }
+    }
+
+    createOrder(schedule) {
         const detailsModal = document.getElementById('scheduleDetailsModal');
-        if (detailsModal) {
+        if (detailsModal && window.app && typeof window.app.closeModal === 'function') {
             window.app.closeModal(detailsModal);
         }
 
         if (typeof window.openClientRequestFormModal === 'function') {
             window.openClientRequestFormModal(schedule);
-        } else if (typeof window.openRequestFormModal === 'function') {
+            return;
+        }
+
+        if (typeof window.openRequestFormModal === 'function') {
             window.openRequestFormModal(schedule, '', '', '', {
                 modalId: 'clientRequestModal',
                 contentId: 'clientRequestModalContent'
             });
-        } else {
-            console.error('openRequestFormModal is not loaded');
-            if (window.app && typeof window.app.showError === 'function') {
-                window.app.showError('Не удалось загрузить форму заявки');
-            }
-        }
-    }
-
-    createOrderForScheduleGroup(groupKey) {
-        const group = this.scheduleGroupsByKey.get(groupKey);
-        if (!group || !Array.isArray(group.scheduleDetails) || group.scheduleDetails.length === 0) {
-            console.warn('Не удалось найти отправления для выбранной даты', groupKey);
             return;
         }
 
-        const clonedDetails = group.scheduleDetails.map((details) => ({ ...details }));
-        const primaryDetails = { ...clonedDetails[0] };
-
-        primaryDetails.available_schedules = clonedDetails;
-        primaryDetails.availableSchedules = clonedDetails;
-
-        if (!primaryDetails.id && group.primaryScheduleId) {
-            primaryDetails.id = group.primaryScheduleId;
-        }
-
-        if (!primaryDetails.accept_date && group.departureDate) {
-            primaryDetails.accept_date = group.departureDate;
-            primaryDetails.acceptDate = group.departureDate;
-        }
-
-        if (!primaryDetails.delivery_date && Array.isArray(group.deliveryDates) && group.deliveryDates.length > 0) {
-            const delivery = group.deliveryDates[0];
-            primaryDetails.delivery_date = delivery;
-            primaryDetails.deliveryDate = delivery;
-        }
-
-        if (clonedDetails.length > 1) {
-            primaryDetails.city = '';
-        }
-
-        if (!primaryDetails.marketplace) {
-            primaryDetails.marketplace = this.filters.marketplace || '';
-        }
-        if (!primaryDetails.warehouse && !primaryDetails.warehouses) {
-            const warehouse = this.filters.warehouse || '';
-            primaryDetails.warehouse = warehouse;
-            primaryDetails.warehouses = warehouse;
-        }
-
-        const detailsModal = document.getElementById('scheduleDetailsModal');
-        if (detailsModal) {
-            window.app.closeModal(detailsModal);
-        }
-
-        if (typeof window.openClientRequestFormModal === 'function') {
-            window.openClientRequestFormModal(primaryDetails);
-        } else if (typeof window.openRequestFormModal === 'function') {
-            window.openRequestFormModal(primaryDetails, '', '', '', {
-                modalId: 'clientRequestModal',
-                contentId: 'clientRequestModalContent'
-            });
-        }
-    }
-
-    showError(message) {
+        console.error('Форма заявки недоступна');
         if (window.app && typeof window.app.showError === 'function') {
-            window.app.showError(message);
-        } else {
-            alert(message);
+            window.app.showError('Не удалось открыть форму заявки');
         }
     }
 
     resetFilters() {
-        this.filters = {
-            marketplace: '',
-            warehouse: ''
-        };
-        this.schedules = [];
-        this.filteredSchedules = [];
-        this.groupedSchedules = [];
-        this.warehouseOptions = [];
-        this.isLoadingSchedules = false;
-        this.pendingSelections.marketplace = '';
-        this.pendingSelections.warehouse = '';
-        this.currentStep = 'marketplace';
-        this.clearWarehouseStats();
-        this.scheduleGroupsByKey.clear();
+        this.state.marketplace = '';
+        this.state.city = '';
+        this.state.weekStart = this.getMonday(new Date());
 
-        this.applyStepState('marketplace', { active: true, complete: false });
-        this.applyStepState('warehouse', { active: false, complete: false });
-        this.clearMarketplaceSummary();
-        this.clearWarehouseSummary();
-        this.updateMarketplaceConfirmState();
-        this.updateWarehouseConfirmState();
-        this.setFiltersCollapsed(false);
-
-        this.setActiveMarketplaceCard('');
-
-        if (this.elements.warehouseSelect) {
-            this.elements.warehouseSelect.value = '';
+        if (this.elements.marketplace) {
+            this.elements.marketplace.value = '';
         }
 
-        this.renderMarketplaces();
-        this.renderWarehouses();
-        this.renderScheduleGrid();
-        this.renderWarehouseStats();
-    }
-
-    getCurrentSelection() {
-        return {
-            marketplace: this.filters.marketplace,
-            warehouse: this.filters.warehouse
-        };
+        this.scheduleCache.clear();
+        this.renderWeekRange();
+        this.loadCities();
+        this.loadSchedules();
     }
 }
 
+window.ScheduleTimeline = ScheduleTimeline;
+
 document.addEventListener('DOMContentLoaded', () => {
-    window.ScheduleManager = new ScheduleManager();
+    window.ScheduleManager = new ScheduleTimeline();
 });

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -313,1061 +313,507 @@ body {
     display: block;
 }
 
-/* Schedule Filters */
+/* Schedule */
 .schedule-panel {
-    gap: 24px;
-    align-items: start;
+    width: 100%;
 }
 
-@media (min-width: 1024px) {
-    .schedule-panel {
-        grid-template-columns: minmax(320px, 360px) minmax(0, 1fr);
+.schedule-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 28px 32px;
+    background: var(--bg-primary);
+    border-radius: 20px;
+    border: 1px solid var(--border-light);
+    box-shadow: var(--shadow-lg);
+}
+
+@media (max-width: 900px) {
+    .schedule-wrap {
+        padding: 24px;
     }
 }
 
-.schedule-panel.filters-collapsed {
-    grid-template-columns: minmax(0, 1fr);
-}
-
-.schedule-panel.filters-expanded .schedule-results {
-    animation: scheduleResultsSlide 0.4s ease;
+@media (max-width: 600px) {
+    .schedule-wrap {
+        padding: 20px 18px;
+        gap: 20px;
+    }
 }
 
 .schedule-filters {
     display: flex;
-    flex-direction: column;
-    gap: 20px;
-    align-items: stretch;
-    background: white;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow);
-    padding: 20px 24px;
-    overflow: hidden;
-    max-height: 1500px;
-    opacity: 1;
-    transform: translateY(0);
-    transition:
-        max-height 0.45s ease,
-        opacity 0.3s ease,
-        transform 0.3s ease,
-        padding 0.3s ease,
-        margin 0.3s ease,
-        border-color 0.3s ease,
-        box-shadow 0.3s ease;
-}
-
-.schedule-panel.filters-collapsed .schedule-filters {
-    max-height: 0;
-    opacity: 0;
-    transform: translateY(-12px);
-    padding-top: 0;
-    padding-bottom: 0;
-    margin: 0;
-    border-color: transparent;
-    box-shadow: none;
-    pointer-events: none;
-}
-
-.schedule-panel.filters-collapsed .schedule-results {
-    grid-column: 1 / -1;
-}
-
-.schedule-filter {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    min-width: 200px;
-}
-
-.schedule-filter label {
-    font-weight: 600;
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-}
-
-.filter-select {
-    width: 100%;
-    padding: 10px 12px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 18px;
     background: var(--bg-secondary);
-    color: var(--text-primary);
-    font-size: 0.95rem;
-    transition: var(--transition);
-    appearance: none;
+    border-radius: 16px;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
 }
 
-.filter-select:focus {
+.schedule-select {
+    appearance: none;
+    padding: 12px 14px;
+    min-width: 220px;
+    max-width: 100%;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-weight: 500;
+    transition: var(--transition);
+    cursor: pointer;
+    background-image: linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),
+        linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%);
+    background-position: calc(100% - 20px) calc(50% - 5px), calc(100% - 14px) calc(50% - 5px);
+    background-size: 6px 6px, 6px 6px;
+    background-repeat: no-repeat;
+    padding-right: 40px;
+    flex: 0 0 auto;
+}
+
+.schedule-select:focus-visible {
     outline: none;
     border-color: var(--primary);
-    box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.15);
-    background: white;
+    box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.18);
 }
 
-.warehouse-stats {
-    display: grid;
-    gap: 16px;
-    border-radius: var(--radius-lg);
-    border: 1px solid transparent;
-    background: transparent;
-    box-shadow: none;
-    padding: 0;
-    margin-top: 0;
-    opacity: 0;
-    transform: translateY(12px);
-    pointer-events: none;
-    max-height: 0;
-    overflow: hidden;
-    transition:
-        opacity 0.3s ease,
-        transform 0.3s ease,
-        max-height 0.3s ease,
-        padding 0.3s ease,
-        margin-top 0.3s ease,
-        border-color 0.3s ease,
-        background 0.3s ease,
-        box-shadow 0.3s ease;
+.schedule-select:disabled {
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    cursor: not-allowed;
 }
 
-.warehouse-stats.is-visible {
-    opacity: 1;
-    transform: translateY(0);
-    pointer-events: auto;
-    background: var(--bg-secondary);
-    border-color: rgba(40, 199, 111, 0.18);
-    box-shadow: var(--shadow-sm);
-    padding: 18px 20px;
-    margin-top: 8px;
-    max-height: 620px;
-}
-
-.warehouse-stats__header {
+.schedule-origin-tabs {
     display: flex;
-    flex-direction: column;
-    gap: 4px;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    padding: 6px;
+    background: var(--bg-primary);
+    border-radius: 14px;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+    min-height: 48px;
+    flex: 1 1 320px;
+    justify-content: flex-start;
 }
 
-.warehouse-stats__title {
+.schedule-origin-tabs.is-hidden {
+    display: none;
+}
+
+.schedule-origin-tab {
+    border: 0;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 10px 16px;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.schedule-origin-tab:hover,
+.schedule-origin-tab:focus-visible {
+    outline: none;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
+}
+
+.schedule-origin-tab.is-active {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 8px 18px rgba(40, 199, 111, 0.26);
+}
+
+.schedule-origin-placeholder {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    padding: 0 8px;
+}
+
+.schedule-week-nav {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin: 4px 0 0;
+}
+
+.schedule-range {
     font-weight: 600;
     font-size: 0.95rem;
-    color: var(--text-primary);
-}
-
-.warehouse-stats__subtitle {
-    font-size: 0.85rem;
     color: var(--text-secondary);
-}
-
-.warehouse-stats__grid {
-    display: grid;
-    gap: 12px;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.warehouse-stats__item {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 14px 16px;
-    border-radius: var(--radius);
-    border: 1px solid rgba(17, 24, 39, 0.06);
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, #ffffff 100%);
-    box-shadow: var(--shadow-sm);
-    min-height: 96px;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.warehouse-stats__item:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow);
-}
-
-.warehouse-stats__label {
-    font-size: 0.78rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: var(--text-secondary);
 }
 
-.warehouse-stats__value {
-    font-size: 1.6rem;
-    font-weight: 700;
+.schedule-btn {
+    border: 0;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    transition: var(--transition);
+    cursor: pointer;
+}
+
+.schedule-btn--nav {
+    width: 44px;
+    height: 44px;
+    font-size: 1.1rem;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    box-shadow: var(--shadow);
+    border: 1px solid var(--border-light);
+}
+
+.schedule-btn--nav:hover {
+    background: var(--bg-tertiary);
     color: var(--primary);
-    line-height: 1.1;
 }
 
-.warehouse-stats__description {
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    line-height: 1.4;
+.schedule-btn--nav:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.24);
 }
 
-.warehouse-stats__item--loading .warehouse-stats__value,
-.warehouse-stats__item--error .warehouse-stats__value {
-    color: var(--text-secondary);
+.schedule-timeline {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 0;
+    border-radius: 18px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-primary);
+    overflow: hidden;
 }
 
-.warehouse-stats__item--error {
-    border-color: rgba(239, 68, 68, 0.25);
-}
-
-.warehouse-stats__item--error .warehouse-stats__description {
-    color: var(--error);
-}
-
-.warehouse-stats__spinner {
-    display: inline-block;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    border: 2px solid rgba(40, 199, 111, 0.25);
-    border-top-color: var(--primary);
-    animation: spin 0.9s linear infinite;
-}
-
-.warehouse-stats__note {
-    font-size: 0.78rem;
-    color: var(--text-secondary);
-    line-height: 1.4;
+@media (max-width: 1200px) {
+    .schedule-timeline {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
 }
 
 @media (max-width: 900px) {
-    .warehouse-stats.is-visible {
-        padding: 16px;
+    .schedule-filters {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .schedule-select {
+        width: 100%;
+    }
+
+    .schedule-timeline {
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 
-@media (max-width: 640px) {
-    .warehouse-stats__grid {
-        grid-template-columns: 1fr;
+@media (max-width: 600px) {
+    .schedule-btn--nav {
+        width: 40px;
+        height: 40px;
+        font-size: 1rem;
     }
 
-    .warehouse-stats__item {
-        min-height: 88px;
+    .schedule-origin-tabs {
+        width: 100%;
+        justify-content: flex-start;
     }
 }
 
-.marketplace-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 12px;
-    width: 100%;
-    transition: opacity 0.3s ease;
+.schedule-day {
+    display: flex;
+    flex-direction: column;
+    background: transparent;
+    border-right: 1px solid var(--border-light);
+    min-height: 100%;
 }
 
-.marketplace-grid.is-loading,
-.marketplace-grid.is-disabled {
-    pointer-events: none;
-    opacity: 0.7;
+.schedule-day:last-child {
+    border-right: none;
 }
 
-.marketplace-grid.is-loading {
-    cursor: progress;
-}
-
-.marketplace-card {
-    position: relative;
+.schedule-day__header {
+    padding: 20px 24px 12px;
+    background: var(--bg-secondary);
+    border-bottom: 2px solid var(--border-light);
     display: flex;
     flex-direction: column;
     gap: 6px;
-    align-items: flex-start;
-    justify-content: center;
-    width: 100%;
-    padding: 16px 18px;
-    min-height: 92px;
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border);
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-    font: inherit;
+}
+
+.schedule-day__weekday {
     font-weight: 600;
-    font-size: 0.95rem;
-    text-align: left;
-    cursor: pointer;
-    box-shadow: var(--shadow-sm);
-    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.2s ease, background-color 0.2s ease;
-    overflow: hidden;
-}
-
-.marketplace-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(40, 199, 111, 0.08), rgba(37, 99, 235, 0.06));
-    opacity: 0;
-    transition: opacity 0.25s ease;
-    pointer-events: none;
-}
-
-.marketplace-card:hover {
-    transform: translateY(-4px);
-    border-color: rgba(40, 199, 111, 0.35);
-    box-shadow: var(--shadow-md);
-}
-
-.marketplace-card:hover::after {
-    opacity: 1;
-}
-
-.marketplace-card:focus-visible {
-    outline: 3px solid rgba(40, 199, 111, 0.35);
-    outline-offset: 2px;
-}
-
-.marketplace-card.is-active {
-    transform: translateY(-4px);
-    border-color: transparent;
-    background: linear-gradient(135deg, var(--primary), var(--primary-light));
-    color: #ffffff;
-    box-shadow: var(--shadow-md);
-}
-
-.marketplace-card.is-active::after {
-    opacity: 0.35;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
-}
-
-.marketplace-card__title {
     font-size: 1rem;
-    letter-spacing: -0.01em;
+    color: var(--text-primary);
+    text-transform: capitalize;
 }
 
-.marketplace-card__description {
-    font-size: 0.82rem;
-    font-weight: 500;
+.schedule-day__date {
+    font-size: 0.8rem;
     color: var(--text-secondary);
-    line-height: 1.35;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
-.marketplace-card.is-active .marketplace-card__description {
-    color: rgba(255, 255, 255, 0.85);
-}
-
-.marketplace-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    padding: 18px;
-    min-height: 92px;
-    border-radius: var(--radius-lg);
-    background: var(--bg-tertiary);
-    color: var(--text-secondary);
-    font-weight: 500;
-    box-shadow: inset 0 0 0 1px var(--border);
-}
-
-.marketplace-placeholder--loading::before {
-    content: '';
-    width: 16px;
-    height: 16px;
-    display: inline-block;
-    border-radius: 50%;
-    border: 2px solid rgba(40, 199, 111, 0.35);
-    border-top-color: var(--primary);
-    animation: spin 0.75s linear infinite;
-}
-
-@media (max-width: 768px) {
-    .marketplace-card {
-        min-height: 84px;
-        padding: 14px 16px;
-    }
-}
-
-@media (max-width: 520px) {
-    .marketplace-grid {
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    }
-}
-
-.filter-select:disabled {
-    opacity: 0.7;
-    cursor: not-allowed;
-}
-
-.reset-filters-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 16px;
-    border: 1px dashed var(--border);
-    border-radius: var(--radius);
-    background: transparent;
-    color: var(--text-secondary);
-    font-weight: 600;
-    cursor: pointer;
-    transition: var(--transition);
-    height: fit-content;
-    align-self: flex-end;
-}
-
-.reset-filters-btn:hover {
-    border-color: var(--primary);
-    color: var(--primary);
-    background: rgba(40, 199, 111, 0.08);
-}
-
-.schedule-steps {
+.schedule-day__list {
     display: flex;
     flex-direction: column;
-    gap: 16px;
-}
-
-.schedule-step {
+    gap: 0;
+    flex: 1;
     background: var(--bg-primary);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-sm);
-    padding: 16px 20px;
-    transition: var(--transition);
-    overflow: hidden;
 }
 
-.schedule-step.is-active {
-    border-color: rgba(40, 199, 111, 0.4);
-    box-shadow: var(--shadow-md);
-    animation: stepReveal 0.35s ease;
+.schedule-day__empty {
+    padding: 20px 12px;
+    text-align: center;
+    color: var(--text-secondary);
+    font-style: italic;
+    font-size: 0.9rem;
+    background: var(--bg-primary);
 }
 
-.schedule-step.is-complete {
-    border-color: rgba(37, 99, 235, 0.25);
+.schedule-shipment {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 18px 24px;
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid var(--border-light);
+    background: var(--bg-primary);
+    cursor: pointer;
+    text-align: left;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.step-header {
+.schedule-shipment:last-child {
+    border-bottom: none;
+}
+
+.schedule-shipment:hover,
+.schedule-shipment:focus-visible {
+    background: var(--bg-secondary);
+    outline: none;
+}
+
+.schedule-shipment__header {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
+    align-items: baseline;
     gap: 12px;
 }
 
-.step-title {
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-}
-
-.step-index {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    background: var(--bg-tertiary);
-    color: var(--primary);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 700;
-    font-size: 0.95rem;
-    transition: var(--transition);
-    flex-shrink: 0;
-}
-
-.schedule-step.is-active .step-index {
-    background: var(--primary);
-    color: white;
-    box-shadow: 0 10px 24px -16px rgba(40, 199, 111, 0.9);
-}
-
-.step-text h3 {
-    font-size: 1.05rem;
+.schedule-shipment__destination {
     font-weight: 600;
+    font-size: 1rem;
     color: var(--text-primary);
 }
 
-.step-text p {
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-    margin-top: 2px;
-}
-
-.step-change-btn {
-    display: none;
-    border: none;
-    background: transparent;
-    color: var(--secondary);
+.schedule-shipment__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 48px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.75rem;
     font-weight: 600;
-    font-size: 0.9rem;
-    cursor: pointer;
-    transition: var(--transition);
-    text-decoration: underline;
-    text-decoration-thickness: 2px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
-.step-change-btn:hover {
-    color: var(--primary);
+.schedule-shipment__badge.badge-wb {
+    background: rgba(111, 66, 193, 0.16);
+    color: #6f42c1;
 }
 
-.schedule-step.is-complete .step-change-btn {
+.schedule-shipment__badge.badge-ozon {
+    background: rgba(37, 99, 235, 0.18);
+    color: #2563eb;
+}
+
+.schedule-shipment__badge.badge-ym {
+    background: rgba(234, 179, 8, 0.18);
+    color: #b45309;
+}
+
+.schedule-shipment__route {
+    font-size: 0.88rem;
+    color: var(--text-secondary);
+    line-height: 1.45;
+}
+
+.schedule-shipment__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.schedule-shipment__chip,
+.schedule-shipment__status {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-}
-
-.step-body {
-    display: none;
-    flex-direction: column;
-    gap: 16px;
-    margin-top: 16px;
-    animation: stepBodyFade 0.35s ease;
-}
-
-.schedule-step.is-active .step-body {
-    display: flex;
-}
-
-.step-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-}
-
-.step-next-btn,
-.step-prev-btn {
-    padding: 10px 18px;
-    border-radius: var(--radius);
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-size: 0.78rem;
     font-weight: 600;
-    cursor: pointer;
-    transition: var(--transition);
-    border: none;
-}
-
-.step-next-btn {
-    background: var(--primary);
-    color: white;
-    box-shadow: 0 14px 30px -18px rgba(40, 199, 111, 0.8);
-}
-
-.step-next-btn:hover:not(:disabled) {
-    background: var(--primary-dark);
-}
-
-.step-next-btn:disabled {
-    background: var(--bg-tertiary);
-    color: var(--text-light);
-    cursor: not-allowed;
-    box-shadow: none;
-}
-
-.step-prev-btn {
-    background: var(--bg-tertiary);
+    background: var(--bg-secondary);
     color: var(--text-secondary);
 }
 
-.step-prev-btn:hover {
-    background: rgba(37, 99, 235, 0.08);
+.schedule-shipment__status.status-open {
+    background: rgba(40, 199, 111, 0.18);
+    color: var(--primary);
+}
+
+.schedule-shipment__status.status-waiting {
+    background: rgba(245, 158, 11, 0.18);
+    color: var(--warning);
+}
+
+.schedule-shipment__status.status-transit {
+    background: rgba(37, 99, 235, 0.18);
     color: var(--secondary);
 }
 
-.step-summary {
-    margin-top: 12px;
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-    display: none;
-    opacity: 0;
-    transform: translateY(-6px);
-    transition: var(--transition);
+.schedule-shipment__status.status-completed {
+    background: rgba(16, 185, 129, 0.16);
+    color: var(--success);
 }
 
-.schedule-step.is-complete .step-summary {
-    display: block;
-    opacity: 1;
-    transform: translateY(0);
+.schedule-shipment__status.status-unknown {
+    background: rgba(148, 163, 184, 0.18);
 }
 
-.schedule-info {
-    color: var(--text-secondary);
-    font-size: 0.95rem;
-}
-
-.schedule-results-header .schedule-info {
-    flex: 1 1 auto;
-    margin: 0;
-}
-
-/* Animations */
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes stepReveal {
-    from {
-        opacity: 0;
-        transform: translateY(18px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes stepBodyFade {
-    from {
-        opacity: 0;
-        transform: translateY(12px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes slideInRight {
-    from {
-        opacity: 0;
-        transform: translateX(30px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
-}
-
-@keyframes createOrderPress {
-    0% {
-        transform: scale(1);
-        box-shadow: 0 18px 32px -18px rgba(40, 199, 111, 0.7);
-    }
-    50% {
-        transform: scale(0.97);
-        box-shadow: 0 12px 26px -18px rgba(40, 199, 111, 0.6);
-    }
-    100% {
-        transform: scale(1);
-        box-shadow: 0 18px 32px -18px rgba(40, 199, 111, 0.7);
-    }
-}
-
-@keyframes scheduleResultsSlide {
-    from {
-        opacity: 0;
-        transform: translateY(12px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-/* Enhanced status colors */
-.status-open {
-    background: linear-gradient(135deg, #dcfce7 0%, #bbf7d0 100%);
-    color: #15803d;
-    border: 1px solid rgba(21, 128, 61, 0.2);
-}
-
-.status-waiting {
-    background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
-    color: #b45309;
-    border: 1px solid rgba(180, 83, 9, 0.2);
-}
-
-.status-transit {
-    background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
-    color: #1d4ed8;
-    border: 1px solid rgba(29, 78, 216, 0.2);
-}
-
-.status-unknown {
-    background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
-    color: #4b5563;
-    border: 1px solid rgba(75, 85, 99, 0.2);
-}
-
-.status-completed {
-    background: linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 100%);
-    color: #3730a3;
-    border: 1px solid rgba(55, 48, 163, 0.2);
-}
-
-.schedule-status-indicator.status-open,
-.schedule-status-indicator.status-waiting,
-.schedule-status-indicator.status-transit,
-.schedule-status-indicator.status-unknown,
-.schedule-status-indicator.status-completed {
-    border: none;
-}
-
-.schedule-header {
+.schedule-shipment__footer {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-bottom: 16px;
+    justify-content: flex-end;
 }
 
-.schedule-route {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--text-primary);
-}
-
-.schedule-marketplace {
-    padding: 6px 12px;
-    border-radius: 999px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    background: var(--bg-tertiary);
-    color: var(--text-secondary);
-}
-
-.marketplace-wb {
-    background: #e91e63;
-    color: white;
-}
-
-.marketplace-ozon {
-    background: #2196f3;
-    color: white;
-}
-
-.marketplace-yandex {
-    background: #ffc107;
-    color: #333;
-}
-
-
-.schedule-results {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-.schedule-results-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    flex-wrap: wrap;
-}
-
-.filter-toggle-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 18px;
-    border-radius: 999px;
-    border: 1px solid transparent;
-    background: var(--bg-secondary);
-    color: var(--primary);
-    font-weight: 600;
-    cursor: pointer;
-    transition: var(--transition);
-}
-
-.filter-toggle-btn:hover,
-.filter-toggle-btn:focus-visible {
-    background: rgba(40, 199, 111, 0.12);
-    color: var(--primary-dark);
-}
-
-.filter-toggle-btn:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(40, 199, 111, 0.15);
-}
-
-.filter-toggle-btn .filter-toggle-icon {
-    font-size: 1rem;
-}
-
-.schedule-panel.filters-collapsed .filter-toggle-btn {
-    background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
-    color: #fff;
-    box-shadow: 0 12px 24px -16px rgba(40, 199, 111, 0.55);
-}
-
-.schedule-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 16px;
-}
-
-.schedule-grid.is-empty {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
-}
-
-.schedule-grid.is-empty .empty-state {
-    max-width: 420px;
-}
-
-.schedule-grid.is-empty .loading {
-    flex-direction: column;
-}
-
-.schedule-card {
-    position: relative;
-    display: flex;
-    background: white;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow);
-    transition: var(--transition);
-    overflow: hidden;
-}
-
-.schedule-card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-lg);
-    border-color: rgba(40, 199, 111, 0.35);
-}
-
-.schedule-status-indicator {
-    width: 6px;
-    background: var(--border);
-    flex-shrink: 0;
-    align-self: stretch;
-    transition: background 0.3s ease;
-}
-
-.schedule-status-indicator.status-open {
-    background: #34d399;
-}
-
-.schedule-status-indicator.status-waiting {
-    background: #fbbf24;
-}
-
-.schedule-status-indicator.status-transit {
-    background: #60a5fa;
-}
-
-.schedule-status-indicator.status-unknown {
-    background: #cbd5f5;
-}
-
-.schedule-status-indicator.status-completed {
-    background: #818cf8;
-}
-
-.schedule-card-body {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-}
-
-.schedule-card-main {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    padding: 20px;
-}
-
-.schedule-card-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-}
-
-.schedule-card-warehouse {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--text-primary);
-}
-
-.schedule-card-dates {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    background: var(--bg-secondary);
-    border-radius: var(--radius);
-    padding: 12px 16px;
-}
-
-.schedule-dates-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-secondary);
-}
-
-.schedule-dates-label {
-    flex: 1;
-}
-
-.schedule-dates-label--departure {
-    text-align: left;
-}
-
-.schedule-dates-label--delivery {
-    text-align: right;
-}
-
-.schedule-dates-icon {
-    font-size: 1rem;
-    color: var(--primary);
-}
-
-.schedule-dates-values {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    column-gap: 16px;
-    row-gap: 4px;
-    align-items: center;
-}
-
-.date-value {
-    font-weight: 600;
-    color: var(--text-primary);
-    font-size: 0.95rem;
-}
-
-.date-value--departure {
-    text-align: left;
-}
-
-.date-value--delivery {
-    text-align: right;
-}
-
-.schedule-card-extra {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    padding: 0 20px;
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    border-top: 1px solid transparent;
-    transition:
-        max-height 0.4s ease,
-        opacity 0.25s ease,
-        padding 0.4s ease,
-        border-top-color 0.3s ease;
-}
-
-.schedule-card.is-expanded .schedule-card-extra {
-    padding: 18px 20px 20px;
-    max-height: 640px;
-    opacity: 1;
-    border-top-color: var(--border-light);
-}
-
-.schedule-status {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 14px;
-    border-radius: 999px;
+.schedule-shipment__action {
     font-size: 0.85rem;
     font-weight: 600;
-    width: fit-content;
+    color: var(--primary);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }
 
-.status-dot {
-    display: inline-block;
-    width: 10px;
-    height: 10px;
+.schedule-shipment__action::after {
+    content: '\f105';
+    font-family: 'Font Awesome 6 Free';
+    font-weight: 900;
+    font-size: 0.75rem;
+    transition: transform 0.2s ease;
+}
+
+.schedule-shipment:hover .schedule-shipment__action::after,
+.schedule-shipment:focus-visible .schedule-shipment__action::after {
+    transform: translateX(4px);
+}
+
+.schedule-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--text-secondary);
+}
+
+.schedule-empty i {
+    font-size: 1.8rem;
+    color: var(--primary);
+}
+
+.schedule-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 60px 16px;
+    color: var(--text-secondary);
+}
+
+.schedule-spinner {
+    width: 36px;
+    height: 36px;
     border-radius: 50%;
-    background: currentColor;
+    border: 4px solid rgba(37, 99, 235, 0.2);
+    border-top-color: var(--secondary);
+    animation: scheduleSpin 0.8s linear infinite;
 }
 
-.schedule-meta {
+@keyframes scheduleSpin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.schedule-modal {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 14px;
+    gap: 16px;
 }
 
-.meta-item {
+.schedule-modal__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px 16px;
+}
+
+.schedule-modal__item {
     display: flex;
     flex-direction: column;
     gap: 4px;
 }
 
-.meta-label {
+.schedule-modal__label {
     font-size: 0.75rem;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
     color: var(--text-secondary);
+    font-weight: 600;
 }
 
-.meta-value {
+.schedule-modal__value {
     font-size: 0.95rem;
-    font-weight: 600;
     color: var(--text-primary);
-    word-break: break-word;
 }
 
-.schedule-action {
+.schedule-modal__actions {
     display: flex;
-    align-items: stretch;
-    width: 100%;
+    justify-content: flex-end;
+    gap: 12px;
 }
 
-.schedule-card-main .schedule-action {
-    margin-top: 0;
-}
-
-.schedule-card-footer {
-    padding: 12px 20px 18px;
-    border-top: 1px solid var(--border-light);
-    display: flex;
-    justify-content: center;
-    background: white;
-}
-
-.schedule-card-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    border: none;
-    background: transparent;
-    color: var(--primary);
-    font-weight: 600;
-    cursor: pointer;
-    transition: color 0.2s ease, transform 0.2s ease;
-}
-
-.schedule-card-toggle:hover,
-.schedule-card-toggle:focus-visible {
-    color: var(--primary-dark);
-    transform: translateY(-1px);
-}
-
-.schedule-card-toggle:focus-visible {
-    outline: none;
-}
-
-.schedule-card-toggle .toggle-icon {
-    transition: transform 0.3s ease;
-}
-
-.schedule-card.is-expanded .schedule-card-toggle .toggle-icon {
-    transform: rotate(180deg);
-}
-
-.create-order-small {
-    padding: 8px 16px;
+.schedule-modal__actions .create-order-btn {
     background: var(--primary);
-    color: white;
+    color: #fff;
     border: none;
     border-radius: var(--radius);
-    font-weight: 500;
+    padding: 12px 20px;
+    font-weight: 600;
     cursor: pointer;
     transition: var(--transition);
 }
 
-.create-order-small:hover {
+.schedule-modal__actions .create-order-btn:hover {
     background: var(--primary-dark);
 }
-
 /* Tariffs */
 .tariffs-filters {
     display: flex;
@@ -2205,31 +1651,6 @@ body {
         padding: 16px;
     }
 
-    .schedule-step {
-        padding: 14px 16px;
-    }
-
-    .step-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 10px;
-    }
-
-    .step-actions {
-        flex-direction: column;
-    }
-
-    .step-next-btn,
-    .step-prev-btn {
-        width: 100%;
-        text-align: center;
-    }
-
-    .reset-filters-btn {
-        align-self: stretch;
-        justify-content: center;
-    }
-
     .filters {
         grid-template-columns: 1fr;
         gap: 16px;
@@ -2260,14 +1681,6 @@ body {
 
     .stats-grid {
         grid-template-columns: 1fr 1fr;
-    }
-
-    .schedule-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .schedule-item-details {
-        grid-template-columns: 1fr;
     }
 
     .orders-controls {


### PR DESCRIPTION
## Summary
- заменена разметка панели расписания на структуру из макета Schedulesadd/testcodex-main с сохранением ключевых идентификаторов
- обновлены стили расписания на базе schedule.css, адаптированы цвета и отступы под текущую тему
- удалены остатки стилей старого пошагового фильтра, чтобы интерфейс соответствовал новому дизайну

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf50bff9a08333bfb98aba4c239d71