### PR TITLE
feat: rework client schedule controller

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -106,8 +106,8 @@ class App {
     loadSectionData(sectionName) {
         switch (sectionName) {
             case 'schedule':
-                if (window.ScheduleManager) {
-                    window.ScheduleManager.loadSchedules();
+                if (window.scheduleController) {
+                    window.scheduleController.loadSchedules();
                 }
                 break;
             case 'tariffs':
@@ -196,8 +196,8 @@ class App {
         const resetBtn = document.getElementById('resetScheduleFilters');
         if (resetBtn) {
             resetBtn.addEventListener('click', () => {
-                if (window.ScheduleManager) {
-                    window.ScheduleManager.resetFilters();
+                if (window.scheduleController) {
+                    window.scheduleController.resetFilters();
                 }
             });
         }


### PR DESCRIPTION
## Summary
- replace the legacy schedule manager with a new controller that loads marketplace and city filters, handles week navigation, and renders shipment cards
- precompute shipment payloads so the request form modal receives complete schedule data on click
- update the app bootstrap code to rely on the new controller instead of the removed manager

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf5bab286c8333ba777fac240e0260