### PR TITLE
Set Wildberries as default marketplace filter

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -81,7 +81,6 @@ if (empty($_SESSION['user_id'])) {
                 <div class="schedule-wrap">
                     <div class="schedule-filters">
                         <select id="marketplace" class="schedule-select" aria-label="Выбор маркетплейса">
-                            <option value="">Все маркетплейсы</option>
                         </select>
                         <div class="schedule-origin-tabs" id="originTabs" role="tablist" aria-label="Города отправления">
                             <!-- Табы городов генерируются динамически -->


### PR DESCRIPTION
## Summary
- default the client schedule filters to the Wildberries marketplace and reset to it when clearing filters
- load marketplace options without the "all marketplaces" placeholder and automatically pick Wildberries (or the first available) while keeping cities in sync
- remove the static "all marketplaces" option from the schedule filter markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf5dfd6ab883339bb00375fda2f093