### PR TITLE
Remove city selection from request form

### DIFF
--- a/client/templates/customOrderModal.html
+++ b/client/templates/customOrderModal.html
@@ -43,23 +43,18 @@
         </div>
 
         <div class="form-group request-form__group request-form__city-group">
-          <label for="city">Город:</label>
+          <label>Город отправления:</label>
           <div class="request-form__city-control">
-            <select id="city" name="city" class="request-form__city-select" autocomplete="off" required>
-              <option value="" disabled selected>Выберите город</option>
-            </select>
+            <span class="request-form__city-value" id="legacyCity">—</span>
           </div>
         </div>
+        <input type="hidden" id="cityField" name="city" value="">
         <input type="hidden" id="warehouses" name="warehouses" value="">
         <input type="hidden" id="driver_name" name="driver_name" value="">
         <input type="hidden" id="driver_phone" name="driver_phone" value="">
         <input type="hidden" id="car_number" name="car_number" value="">
         <input type="hidden" id="car_brand" name="car_brand" value="">
         <input type="hidden" id="sender" name="sender" value="">
-
-        <p id="citySelectionNotice" class="request-form__city-notice" role="status" aria-live="polite">
-          Пожалуйста, выберите город отправления…
-        </p>
 
         <div id="cityDependentFields" class="request-form__city-dependent">
           <div class="form-group request-form__group">

--- a/requestForm.js
+++ b/requestForm.js
@@ -327,6 +327,17 @@ function fillLegacyFormFields(container, scheduleData) {
         }
     }
 
+    const cityDisplay = container.querySelector('#legacyCity');
+    if (cityDisplay) {
+        const cityText = city || '—';
+        cityDisplay.textContent = cityText;
+        if (city && typeof cityDisplay.setAttribute === 'function') {
+            cityDisplay.setAttribute('title', city);
+        } else if (typeof cityDisplay.removeAttribute === 'function') {
+            cityDisplay.removeAttribute('title');
+        }
+    }
+
     const setValue = (selector, value = '') => {
         const el = container.querySelector(selector);
         if (el) el.value = value;
@@ -338,7 +349,7 @@ function fillLegacyFormFields(container, scheduleData) {
     setValue('#deliveryDateAlias', deliveryDate || '');
     setValue('#acceptTimeField', acceptTime || '');
     setValue('#directionField', warehouse || '');
-    setValue('#city', city || '');
+    setValue('#cityField', city || '');
     setValue('#warehouses', warehouse || '');
     setValue('#driver_name', driverName || '');
     setValue('#driver_phone', driverPhone || '');
@@ -349,8 +360,8 @@ function fillLegacyFormFields(container, scheduleData) {
     const formElement = container.querySelector('#dataForm');
     if (formElement) {
         formElement.dataset.marketplace = marketplace || '';
-        formElement.dataset.initialCity = city || '';
-        formElement.dataset.initialWarehouse = warehouse || '';
+        formElement.dataset.scheduleCity = city || '';
+        formElement.dataset.scheduleWarehouse = warehouse || '';
         if (Array.isArray(scheduleData.availableSchedules) && scheduleData.availableSchedules.length > 0) {
             try {
                 formElement.dataset.availableSchedules = JSON.stringify(scheduleData.availableSchedules);


### PR DESCRIPTION
## Summary
- replace the city selector in the custom order modal with a static display and hidden field
- update requestForm.js to fill the new city field from schedule data and adjust stored dataset keys
- simplify initializeForm in form.js to auto-apply schedule details without city selection and align the inline template

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf6155231083338f4a0b2471c26e14