### PR TITLE
Упростить карточки отправлений в расписании

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -817,13 +817,6 @@ class ScheduleController {
 
         button.appendChild(header);
 
-        if (entry.city) {
-            const route = document.createElement('div');
-            route.className = 'schedule-shipment__route';
-            route.textContent = `${entry.city} → ${entry.warehouse || '—'}`;
-            button.appendChild(route);
-        }
-
         const meta = document.createElement('div');
         meta.className = 'schedule-shipment__meta';
 
@@ -852,16 +845,6 @@ class ScheduleController {
         if (meta.childNodes.length > 0) {
             button.appendChild(meta);
         }
-
-        const footer = document.createElement('div');
-        footer.className = 'schedule-shipment__footer';
-
-        const info = document.createElement('span');
-        info.className = 'schedule-shipment__info';
-        info.textContent = 'Оформить заявку';
-        footer.appendChild(info);
-
-        button.appendChild(footer);
 
         button.addEventListener('click', () => {
             this.openRequestForm(entry);

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -647,12 +647,6 @@ body {
     color: #b45309;
 }
 
-.schedule-shipment__route {
-    font-size: 0.88rem;
-    color: var(--text-secondary);
-    line-height: 1.45;
-}
-
 .schedule-shipment__meta {
     display: flex;
     flex-wrap: wrap;
@@ -694,33 +688,6 @@ body {
 
 .schedule-shipment__status.status-unknown {
     background: rgba(148, 163, 184, 0.18);
-}
-
-.schedule-shipment__footer {
-    display: flex;
-    justify-content: flex-end;
-}
-
-.schedule-shipment__action {
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--primary);
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-}
-
-.schedule-shipment__action::after {
-    content: '\f105';
-    font-family: 'Font Awesome 6 Free';
-    font-weight: 900;
-    font-size: 0.75rem;
-    transition: transform 0.2s ease;
-}
-
-.schedule-shipment:hover .schedule-shipment__action::after,
-.schedule-shipment:focus-visible .schedule-shipment__action::after {
-    transform: translateX(4px);
 }
 
 .schedule-empty {


### PR DESCRIPTION
## Summary
- удалить блоки маршрута и футера из карточек расписания, оставив только заголовок и метаданные
- убрать неиспользуемые правила CSS для удалённых элементов

## Testing
- npm run build (падает: Could not resolve entry module "index.html")

------
https://chatgpt.com/codex/tasks/task_e_68cf72cb64288333adb565aea21a7e6f