### PR TITLE
Remove vertical gap between schedule day cards

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -579,7 +579,7 @@ body {
     display: grid;
     grid-template-columns: 1fr;
     grid-auto-rows: var(--schedule-card-height, 200px);
-    gap: 12px;
+    row-gap: 0;
     flex: 1;
     background: var(--bg-primary);
 }


### PR DESCRIPTION
## Summary
- replace the `.schedule-day__list` grid gap with `row-gap: 0` so the schedule cards have only their divider lines between rows

## Testing
- php -S 0.0.0.0:8000 (fails: requires unavailable MySQL connection)


------
https://chatgpt.com/codex/tasks/task_e_68cf84d3e1108333b4ac800ad59ad04f