### PR TITLE
Adjust schedule card height and empty state styles

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -23,19 +23,7 @@
     --radius: 8px;
     --radius-lg: 12px;
     --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    --schedule-card-height: 200px;
-}
-
-@media (max-width: 1024px) {
-    :root {
-        --schedule-card-height: 220px;
-    }
-}
-
-@media (max-width: 768px) {
-    :root {
-        --schedule-card-height: 240px;
-    }
+    --schedule-card-height: clamp(168px, 21vh, 184px);
 }
 
 /* Reset and Base */
@@ -578,19 +566,41 @@ body {
 .schedule-day__list {
     display: grid;
     grid-template-columns: 1fr;
-    grid-auto-rows: var(--schedule-card-height, 200px);
+    grid-auto-rows: var(--schedule-card-height, 184px);
     row-gap: 0;
     flex: 1;
     background: var(--bg-primary);
 }
 
+.schedule-day__placeholder,
 .schedule-day__empty {
-    padding: 20px 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 18px 24px;
+    height: 100%;
+    min-height: var(--schedule-card-height);
+    border-bottom: 1px solid var(--border-light);
+    background: var(--bg-primary);
     text-align: center;
+}
+
+.schedule-day__placeholder {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    gap: 8px;
+}
+
+.schedule-day__empty {
     color: var(--text-secondary);
     font-style: italic;
     font-size: 0.9rem;
-    background: var(--bg-primary);
+    gap: 6px;
+}
+
+.schedule-day__placeholder:last-child,
+.schedule-day__empty:last-child {
+    border-bottom: none;
 }
 
 .schedule-shipment {


### PR DESCRIPTION
## Summary
- reduce the base schedule card height and use a clamp-based CSS variable instead of media queries
- keep the schedule grid rows aligned to the updated variable and improve placeholder/empty cell styling to fill the track

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf8ffaace0833398abe6864458d983