### PR TITLE
Сократить подписи складов в расписании

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -817,7 +817,43 @@ class ScheduleController {
 
         const destination = document.createElement('span');
         destination.className = 'schedule-shipment__destination';
-        destination.textContent = entry.warehouse || 'Склад не указан';
+
+        const warehouseName =
+            typeof entry.warehouse === 'string' && entry.warehouse.trim().length > 0
+                ? entry.warehouse.trim()
+                : 'Склад не указан';
+
+        const shouldShorten = warehouseName.length > 25 || warehouseName.includes(' - ');
+
+        if (shouldShorten) {
+            const parts = warehouseName.split(' - ');
+
+            if (parts.length > 1) {
+                const [firstPart, secondPart = '', ...restParts] = parts;
+                const words = secondPart.trim().split(/\s+/).filter(Boolean);
+
+                if (words.length > 0) {
+                    const [firstWord, ...otherWords] = words;
+                    const abbreviatedSecondPart = [
+                        `${firstWord.charAt(0)}.`,
+                        ...otherWords
+                    ]
+                        .join(' ')
+                        .trim();
+
+                    const restTail = restParts.length ? ` - ${restParts.join(' - ')}` : '';
+                    destination.textContent = `${firstPart} - ${abbreviatedSecondPart}${restTail}`.trim();
+                } else {
+                    destination.textContent = warehouseName;
+                }
+            } else {
+                destination.textContent = warehouseName;
+            }
+
+            destination.classList.add('schedule-shipment__destination--long');
+        } else {
+            destination.textContent = warehouseName;
+        }
         header.appendChild(destination);
 
         const badgeText = this.getMarketplaceBadge(entry.marketplace);

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -643,6 +643,16 @@ body {
     color: var(--text-primary);
 }
 
+.schedule-shipment__destination--long {
+    font-size: 0.68rem;
+    line-height: 1.3;
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+}
+
 .schedule-shipment__badge {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- добавить обработку длинных названий складов в schedule.js и сокращать вторую часть после дефиса
- помечать такие подписи классом schedule-shipment__destination--long для специального оформления
- добавить в CSS стиль для уменьшенного шрифта и ограничения подписи двумя строками

## Testing
- node - <<'NODE'
const entry = { warehouse: 'Екатеринбург - Перспективный 12/2' };
const createDisplay = (value) => {
    const warehouseName = typeof value === 'string' && value.trim().length > 0 ? value.trim() : 'Склад не указан';
    const shouldShorten = warehouseName.length > 25 || warehouseName.includes(' - ');
    if (!shouldShorten) {
        return warehouseName;
    }
    const parts = warehouseName.split(' - ');
    if (parts.length > 1) {
        const [firstPart, secondPart = '', ...restParts] = parts;
        const words = secondPart.trim().split(/\s+/).filter(Boolean);
        if (words.length > 0) {
            const [firstWord, ...otherWords] = words;
            const abbreviatedSecondPart = [`${firstWord.charAt(0)}.`, ...otherWords].join(' ').trim();
            const restTail = restParts.length ? ` - ${restParts.join(' - ')}` : '';
            return `${firstPart} - ${abbreviatedSecondPart}${restTail}`.trim();
        }
    }
    return warehouseName;
};
console.log(createDisplay(entry.warehouse));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cf94af3e948333b4cb4fe86d659e3a