### PR TITLE
Fix shipment header alignment

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -638,7 +638,7 @@ body {
 .schedule-shipment__header {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: flex-start;
     gap: 12px;
 }
 
@@ -662,6 +662,7 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    align-self: flex-start;
     min-width: 48px;
     padding: 4px 10px;
     border-radius: 999px;


### PR DESCRIPTION
## Summary
- align schedule shipment header items to the top edge
- pin the badge to the top to avoid shifts when the title wraps

## Testing
- npm run build *(fails: Could not resolve entry module "index.html" when running Vite build)*

------
https://chatgpt.com/codex/tasks/task_e_68d0835034ac8333bcf939544acfd80b