### PR TITLE
Adjust schedule card height behavior

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -566,7 +566,7 @@ body {
 .schedule-day__list {
     display: grid;
     grid-template-columns: 1fr;
-    grid-auto-rows: var(--schedule-card-height, 184px);
+    grid-auto-rows: minmax(var(--schedule-card-height, 184px), auto);
     row-gap: 0;
     flex: 1;
     background: var(--bg-primary);
@@ -595,7 +595,6 @@ body {
     flex: 1;
     padding: 18px 24px;
     width: 100%;
-    height: 100%;
     background: transparent;
     text-align: center;
 }
@@ -620,7 +619,6 @@ body {
     gap: 12px;
     padding: 18px 24px;
     width: 100%;
-    height: 100%;
     border: none;
     background: var(--bg-primary);
     cursor: pointer;


### PR DESCRIPTION
## Summary
- allow schedule grid rows to expand beyond the default card height when content requires it
- remove the forced 100% height on schedule shipment cards so chips and badges fit without clipping under overflow constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d086fa70a48333a3b42b4babf1e52c