### PR TITLE
Remove fixed height from schedule day spacer

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -577,7 +577,6 @@ body {
     align-items: stretch;
     justify-content: stretch;
     padding: 0;
-    height: var(--schedule-card-height);
     min-height: var(--schedule-card-height);
     border-bottom: 1px solid var(--border-light);
     background: transparent;


### PR DESCRIPTION
## Summary
- remove the fixed height from schedule day spacer to allow cards to grow with content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0907d4398833387e5b559dbea981b