### PR TITLE
Добавить цвета бейджей маркетплейсов

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -929,10 +929,17 @@ class ScheduleController {
             typeof entry.marketplace === 'string' ? entry.marketplace.trim() : '';
         const marketplaceLabel =
             this.getMarketplaceBadge(entry.marketplace) || normalizedMarketplace;
+        const marketplaceModifier = this.getMarketplaceModifier(marketplaceLabel);
 
         if (marketplaceLabel) {
             const marketplace = document.createElement('span');
             marketplace.className = 'schedule-shipment__marketplace';
+            if (marketplaceModifier) {
+                marketplace.classList.add(`schedule-shipment__marketplace--${marketplaceModifier}`);
+            }
+            if (normalizedMarketplace) {
+                marketplace.dataset.marketplace = normalizedMarketplace;
+            }
             marketplace.textContent = marketplaceLabel;
 
             if (acceptElement && acceptElement.parentNode === meta) {
@@ -976,6 +983,23 @@ class ScheduleController {
             return 'YM';
         }
         return marketplace.length > 3 ? marketplace.slice(0, 3).toUpperCase() : marketplace;
+    }
+
+    getMarketplaceModifier(label) {
+        if (!label) {
+            return '';
+        }
+
+        const normalized = label.toLowerCase();
+        if (normalized === 'wb') {
+            return 'wb';
+        }
+
+        if (normalized === 'oz') {
+            return 'oz';
+        }
+
+        return '';
     }
 
     getStatusClass(status) {

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -680,6 +680,14 @@ body {
     border-radius: 0;
 }
 
+.schedule-shipment__marketplace--wb {
+    color: #9a10f0;
+}
+
+.schedule-shipment__marketplace--oz {
+    color: #005bff;
+}
+
 .schedule-shipment__chip,
 .schedule-shipment__status {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- добавить определение модификаторов бейджей маркетплейсов в расписании и прокинуть исходное название в data-атрибут
- расширить стили расписания отдельными цветами для Wildberries и Ozon, сохранив базовый цвет для прочих бейджей

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d09aa79624833397e1791f16ad4b22