### PR TITLE
Уплотнение мобильного фильтра расписания

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -594,11 +594,28 @@ body {
     .schedule-origin-tabs {
         width: 100%;
         justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        gap: 6px;
+        padding: 4px 2px;
+        min-height: auto;
+        scrollbar-width: thin;
     }
 
     .schedule-day-switcher__button {
         padding: 8px 12px;
         font-size: 0.9rem;
+    }
+
+    .schedule-filters {
+        padding: 12px 14px;
+        gap: 8px;
+    }
+
+    .schedule-origin-tab {
+        padding: 8px 12px;
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
## Summary
- отключил перенос пунктов в .schedule-origin-tabs на мобильных ширинах и добавил горизонтальную прокрутку
- уменьшил отступы и зазоры у мобильных фильтров расписания, чтобы табы городов занимали меньше места

## Testing
- `php -S 0.0.0.0:8000` *(ошибка авторизации в БД в тестовом окружении)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d58549f48333ad10fb4e1e68ced2