### PR TITLE
Fix marketplace badge placement in schedule cards

### DIFF
--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -719,6 +719,8 @@ body {
     flex-direction: column;
     gap: 8px;
     padding: 12px 16px;
+    padding-right: 72px;
+    padding-bottom: 48px;
     width: 100%;
     border: none;
     background: var(--bg-primary);
@@ -768,17 +770,26 @@ body {
     flex-wrap: wrap;
     gap: 8px;
     margin-top: auto;
+    padding-right: 72px;
 }
 
 .schedule-shipment__marketplace {
     display: inline-flex;
     align-items: center;
+    position: absolute;
+    right: 16px;
+    bottom: 12px;
+    justify-content: flex-end;
     font-size: 0.78rem;
     font-weight: 600;
     color: var(--text-secondary);
     line-height: 1.2;
     background: none;
     border-radius: 0;
+    max-width: calc(100% - 32px);
+    text-align: right;
+    white-space: normal;
+    word-break: break-word;
 }
 
 .schedule-shipment__marketplace--wb {


### PR DESCRIPTION
## Summary
- increase the right and bottom padding on schedule cards to reserve space for the pinned marketplace badge
- pin the marketplace badge to the bottom-right corner and limit its width/line wrapping to avoid overlap
- add right-side padding to the metadata section so chips and status texts stay clear of the badge

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0dd5ff49c8333b4ad231c1d9b7d59