### PR TITLE
Fix schedule deadline waiting status styling

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -1505,6 +1505,8 @@ class ScheduleController {
 
             if (shouldShowAcceptDeadline) {
                 statusText = `Приём до ${acceptDeadlineLabelForStatus}`;
+                statusElement.classList.remove('status-open');
+                statusElement.classList.add('status-waiting');
             }
 
             statusElement.textContent = statusText;
@@ -1631,16 +1633,17 @@ class ScheduleController {
         ]);
 
         const normalized = status.toLowerCase().trim();
+        const normalizedWithoutYo = normalized.replace(/ё/g, 'е');
 
         if (map.has(normalized)) {
             return map.get(normalized);
         }
 
-        if (normalized.startsWith('Приём до ')) {
-            return map.get('приём заявок');
+        if (normalized.startsWith('приём до ') || normalizedWithoutYo.startsWith('прием до ')) {
+            return 'status-waiting';
         }
 
-        if (normalized.startsWith('прием заявок до ')) {
+        if (normalized.startsWith('приём заявок до ') || normalizedWithoutYo.startsWith('прием заявок до ')) {
             return map.get('прием заявок');
         }
 


### PR DESCRIPTION
## Summary
- update status badges to switch from open to waiting when showing accept deadlines so cards turn yellow
- extend status mapping so API values like "Приём до …" and "прием до …" map to the waiting style

## Testing
- npm run build *(fails: Could not resolve entry module "index.html")*
- node - <<'NODE' (custom check for getStatusClass returning status-waiting for deadline statuses)


------
https://chatgpt.com/codex/tasks/task_e_68d0fb8046c48333b321750868710f1e