### PR TITLE
Обновить состояние закрытых приёмов

### DIFF
--- a/client/js/schedule.js
+++ b/client/js/schedule.js
@@ -1567,8 +1567,8 @@ class ScheduleController {
                 meta.insertBefore(statusElement, meta.firstChild || null);
             }
 
-            statusElement.className = 'schedule-shipment__status status-unknown';
-            statusElement.textContent = 'Завершено';
+            statusElement.className = 'schedule-shipment__status status-closed';
+            statusElement.textContent = 'Приём закрыт';
         }
 
         if (meta.childElementCount > 0) {
@@ -1629,7 +1629,9 @@ class ScheduleController {
             ['прием заявок', 'status-open'],
             ['ожидает отправки', 'status-waiting'],
             ['в пути', 'status-transit'],
-            ['завершено', 'status-completed']
+            ['завершено', 'status-closed'],
+            ['приём закрыт', 'status-closed'],
+            ['прием закрыт', 'status-closed']
         ]);
 
         const normalized = status.toLowerCase().trim();
@@ -1657,7 +1659,7 @@ class ScheduleController {
                 const isStillAccepting = Date.now() < deadlineTime;
                 entry.isAcceptingRequests = isStillAccepting;
                 if (!isStillAccepting) {
-                    const message = 'Завершено';
+                    const message = 'Приём закрыт';
                     if (window.app && typeof window.app.showError === 'function') {
                         window.app.showError(message);
                     } else {

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -828,6 +828,11 @@ body {
     color: var(--secondary);
 }
 
+.schedule-shipment__status.status-closed {
+    background: rgba(239, 68, 68, 0.18);
+    color: var(--error);
+}
+
 .schedule-shipment__status.status-completed {
     background: rgba(16, 185, 129, 0.16);
     color: var(--success);


### PR DESCRIPTION
## Summary
- заменить текст статуса завершённого приёма на «Приём закрыт» и направить его в новый класс `status-closed`
- обновить отображение сообщений о закрытом приёме и добавить стиль для подсветки карточки красным

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0fd662e988333bd5431359d04fbbf