### PR TITLE
Set PDF download button type to button

### DIFF
--- a/fbs/fbs.js
+++ b/fbs/fbs.js
@@ -681,6 +681,7 @@ function saveFBSRecord() {
                 if (!document.getElementById('downloadPdfBtn')) {
                     const pdfBtn = document.createElement('button');
                     pdfBtn.id = 'downloadPdfBtn';
+                    pdfBtn.type = 'button';
                     pdfBtn.className = 'confirm-btn';
                     pdfBtn.textContent = 'Скачать PDF';
                     pdfBtn.onclick = generateFbsPdf;


### PR DESCRIPTION
## Summary
- set the generated PDF download button to type="button" to prevent unintended form submission

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d15bb6fd9883338958e213b018b4d3