### PR TITLE
Добавить логирование проблем расписания

### DIFF
--- a/log_schedule_issue.php
+++ b/log_schedule_issue.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+$rawInput = file_get_contents('php://input');
+$data = null;
+
+if ($rawInput !== false && $rawInput !== '') {
+    $decoded = json_decode($rawInput, true);
+    if (json_last_error() === JSON_ERROR_NONE) {
+        $data = $decoded;
+    } else {
+        $data = ['raw' => $rawInput];
+    }
+}
+
+if ($data === null) {
+    $data = $_POST;
+}
+
+if (!is_array($data)) {
+    $data = ['raw' => $rawInput];
+}
+
+$logDir = __DIR__ . '/logs';
+$logFile = $logDir . '/mobile_schedule_debug.log';
+
+if (!is_dir($logDir)) {
+    mkdir($logDir, 0775, true);
+}
+
+$entry = [
+    'timestamp' => date('c'),
+    'ip' => $_SERVER['REMOTE_ADDR'] ?? '',
+    'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
+    'payload' => $data
+];
+
+file_put_contents(
+    $logFile,
+    json_encode($entry, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL,
+    FILE_APPEND | LOCK_EX
+);
+
+http_response_code(204);


### PR DESCRIPTION
## Summary
- добавлен helper logScheduleIssue в клиентском расписании для отправки диагностических событий
- реализованы вызовы логирования при открытии мобильной версии и обработке ошибок загрузки
- создан серверный обработчик log_schedule_issue.php, записывающий события в logs/mobile_schedule_debug.log

## Testing
- php -l log_schedule_issue.php
- curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -d '{"event":"curl_test","message":"Ошибка загрузки"}' http://127.0.0.1:8000/log_schedule_issue.php

------
https://chatgpt.com/codex/tasks/task_e_68d15fc8e38083338f9ecb25611823a6