### PR TITLE
Ensure schedule assets respect version cache busting

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -329,6 +329,9 @@ $assetVersion = filemtime(__FILE__) ?: time();
         </div>
     </div>
 
+    <script>
+        window.assetVersion = <?php echo json_encode($assetVersion); ?>;
+    </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
     <script src="../requestForm.js?v=<?php echo $assetVersion; ?>"></script>
     <script src="js/app.js?v=<?php echo $assetVersion; ?>"></script>

--- a/client/js/schedule/index.js
+++ b/client/js/schedule/index.js
@@ -1,1 +1,9 @@
-import '../schedule.js';
+const versionSuffix =
+    typeof window !== 'undefined' && window.assetVersion
+        ? `?v=${window.assetVersion}`
+        : '';
+
+import(`../schedule.js${versionSuffix}`)
+    .catch((error) => {
+        console.error('Не удалось загрузить модуль расписания', error);
+    });


### PR DESCRIPTION
## Summary
- expose the PHP asset version globally in the client so JavaScript can reuse it
- switch schedule entrypoint and filter module loading to dynamic imports with version suffixes to avoid stale caches
- initialize the schedule controller only after the filter module has loaded successfully

## Testing
- php -l client/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d187498d7c83338d9f3727be9a09e4